### PR TITLE
Refactor: Dapp content page

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,13 @@
       "Bash(rtk read *)",
       "Bash(rtk find *)",
       "Bash(rtk npx *)",
-      "Bash(bunx react-doctor *)"
+      "Bash(bunx react-doctor *)",
+      "Bash(rtk wc *)",
+      "Bash(bunx tsc *)",
+      "Bash(echo \"tsc exit: $?\")",
+      "Bash(timeout 300 bun run build)",
+      "Bash(bun lint *)",
+      "Bash(rtk grep *)"
     ]
   }
 }

--- a/src/app/ai-services/[domain]/page.tsx
+++ b/src/app/ai-services/[domain]/page.tsx
@@ -1,73 +1,52 @@
 "use client";
 
-import { PaymentData } from "@/app/receipt/receipt-content";
 import { ContactSupport } from "@/components/contact-support";
 import { PageHeader } from "@/components/page-header";
+import { AiServiceDappPayment } from "@/components/ai-services/ai-service-dapp-payment";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { CustomTooltip } from "@/components/ui/custom-tooltip";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useBookmarks } from "@/contexts/BookmarkContext";
-import { useRozoPointAPI } from "@/hooks/useRozoPointAPI";
 import { useRozoWallet } from "@/hooks/useRozoWallet";
 import { getAiServiceById } from "@/lib/ai-services";
-import {
-  formatRozoErrorMessage,
-  isRozoProviderError,
-  isUserCancellation,
-} from "@/lib/rozo-errors";
-import { savePaymentReceipt } from "@/lib/payment-storage";
 import { getFirstTwoWordInitialsFromName } from "@/lib/utils";
 import { useComposeCast, useIsInMiniApp } from "@coinbase/onchainkit/minikit";
-import { useAppKitAccount } from "@reown/appkit/react";
-import {
-  baseUSDC,
-  createPayment,
-  PaymentCompletedEvent,
-  rozoStellarUSDC,
-} from "@rozoai/intent-common";
-import { RozoPayButton, useRozoPayUI } from "@rozoai/intent-pay";
 import {
   Bookmark,
-  Coins,
   CreditCard,
-  HelpCircle,
   MessageCircle,
   Share,
-  Wallet,
 } from "lucide-react";
-import { useParams, useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { toast } from "sonner";
 
-const toAddress = "0x5772FBe7a7817ef7F586215CA8b23b8dD22C8897";
+const AiServiceDiscoveryPayment = dynamic(
+  () =>
+    import("@/components/ai-services/ai-service-discovery-payment").then(
+      (m) => m.AiServiceDiscoveryPayment,
+    ),
+  { ssr: false },
+);
+
+const APP_ID = "rozoRewardsBNBStellarMP-zen";
 
 export default function AIServiceDetailPage() {
+  const searchParams = useSearchParams();
+  const isDapp = searchParams.get("dapp") === "true";
   const params = useParams();
   const router = useRouter();
   const serviceId = params.domain as string;
   const { isInMiniApp } = useIsInMiniApp();
 
   const { composeCast } = useComposeCast();
-  const { resetPayment } = useRozoPayUI();
-  const { getPoints, spendPoints } = useRozoPointAPI();
-  const { address, isConnected } = useAppKitAccount();
   const {
     isAvailable: isRozoWalletAvailable,
     isConnected: isRozoWalletConnected,
     walletAddress: rozoWalletAddress,
-    balance: rozoWalletBalance,
-    transferUSDC: rozoWalletTransfer,
   } = useRozoWallet();
 
   const [service, setService] =
@@ -75,13 +54,7 @@ export default function AIServiceDetailPage() {
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
   const [paymentLoading, setPaymentLoading] = React.useState(false);
-  const [points, setPoints] = React.useState(0);
-  const [showConfirmDialog, setShowConfirmDialog] = React.useState(false);
-  const [dialogLoading, setDialogLoading] = React.useState(false);
-  const [isRozoWalletPaymentLoading, setIsRozoWalletPaymentLoading] =
-    React.useState(false);
   const [showPaymentOptions, setShowPaymentOptions] = React.useState(false);
-  const [appId, setAppId] = React.useState<string>("");
   const [userEmail, setUserEmail] = React.useState<string>("");
   const [emailError, setEmailError] = React.useState<string>("");
   const hasAutoOpenedIntercomRef = useRef(false);
@@ -92,8 +65,6 @@ export default function AIServiceDetailPage() {
     () => `${(service?.id || "service").toUpperCase()}-${Date.now()}`,
     [service?.id],
   );
-  const receiptUrl = `https://ns.rozo.ai/payment/success?order_id=${merchantOrderId}`;
-  const priceUsd = service?.price_usd ?? 0;
   const hasPrice = typeof service?.price_usd === "number";
   const hasDiscount =
     typeof service?.price_usd === "number" &&
@@ -107,53 +78,11 @@ export default function AIServiceDetailPage() {
       )
     : null;
 
-  // Prefer Rozo Wallet account when available, otherwise fall back to EVM account
-  const activeAddress =
-    (isRozoWalletConnected && rozoWalletAddress) ||
-    (isConnected && address) ||
-    "";
-
-  const metadata = useMemo(() => {
-    const baseMetadata = {
-      amount_local: service?.price_usd,
-      currency_local: "USD",
-      email: userEmail,
-      items: [
-        {
-          name: service?.name,
-          description: `${service?.price_usd ?? "N/A"} USD`,
-        },
-      ],
-    };
-
-    if (service?.id) {
-      return {
-        ...baseMetadata,
-        merchant_order_id: merchantOrderId,
-        ...(service?.sold_out ? { receiptUrl: receiptUrl } : {}),
-        items: [
-          ...baseMetadata.items,
-          {
-            name: "Order ID",
-            description: merchantOrderId,
-          },
-        ],
-      };
-    }
-
-    return baseMetadata;
-  }, [
-    service?.price_usd,
-    service?.name,
-    service?.id,
-    service?.sold_out,
-    userEmail,
-    merchantOrderId,
-    receiptUrl,
-  ]);
+  // Prefer Rozo Wallet account when available
+  const activeAddress = (isRozoWalletConnected && rozoWalletAddress) || "";
 
   useEffect(() => {
-    async function loadService() {
+    function loadService() {
       try {
         const foundService = getAiServiceById(serviceId);
         if (!foundService) {
@@ -161,21 +90,6 @@ export default function AIServiceDetailPage() {
         }
 
         setService(foundService);
-
-        const appId = `rozoRewardsBNBStellarMP-zen`;
-        setAppId(appId);
-
-        await resetPayment({
-          appId: appId,
-          intent: `Pay for ${foundService.name}`,
-          toAddress: "0x5772FBe7a7817ef7F586215CA8b23b8dD22C8897",
-          toChain: baseUSDC.chainId,
-          toToken: baseUSDC.token as `0x${string}`,
-          ...(typeof foundService.price_usd === "number" && {
-            toUnits: foundService.price_usd.toString(),
-          }),
-          metadata: metadata as any,
-        });
       } catch (err) {
         setError(err instanceof Error ? err.message : "Unknown error");
       } finally {
@@ -186,34 +100,7 @@ export default function AIServiceDetailPage() {
     if (serviceId) {
       loadService();
     }
-  }, [serviceId, userEmail, metadata]);
-
-  useEffect(() => {
-    const fetchPoints = async () => {
-      if (!address || !isConnected) return;
-
-      const points = await getPoints(address);
-      setPoints(points / 100);
-    };
-    fetchPoints();
-  }, [isConnected, address, getPoints]);
-
-  // Update payment metadata when email changes (but only after initial load)
-  useEffect(() => {
-    if (userEmail && service && appId) {
-      resetPayment({
-        appId: appId,
-        intent: `Pay for ${service.name}`,
-        toAddress: "0x5772FBe7a7817ef7F586215CA8b23b8dD22C8897",
-        toChain: baseUSDC.chainId,
-        toToken: baseUSDC.token as `0x${string}`,
-        ...(typeof service.price_usd === "number" && {
-          toUnits: service.price_usd.toString(),
-        }),
-        metadata: metadata as any,
-      });
-    }
-  }, [userEmail, service, appId, metadata]);
+  }, [serviceId]);
 
   const validateEmail = (email: string): boolean => {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -233,176 +120,6 @@ export default function AIServiceDetailPage() {
 
     setEmailError("");
     return true;
-  };
-
-  const handlePayWithPoints = () => {
-    if (!validateEmailInput()) {
-      return;
-    }
-    setShowConfirmDialog(true);
-  };
-
-  const confirmPaymentWithPoints = async () => {
-    if (!address || !service) return;
-
-    setDialogLoading(true);
-
-    const paymentData = {
-      from_address: address,
-      to_handle: service.id,
-      amount_usd_cents: priceUsd * 100,
-      amount_local: priceUsd,
-      currency_local: "USD",
-      timestamp: Date.now(),
-      order_id: merchantOrderId,
-      about: `Pay for ${service.name}`,
-    };
-
-    const response = await spendPoints(paymentData);
-
-    if (response && response.status === "success") {
-      // Store payment data in localStorage for receipt page
-      const receiptData = {
-        ...response.data,
-        service_name: service.name,
-        service_domain: service.id,
-        is_using_points: true,
-      };
-
-      console.log("[AI Services] Pay with Points - About to save receipt:", {
-        merchantOrderId,
-        receiptData,
-      });
-      savePaymentReceipt(merchantOrderId, receiptData);
-      console.log(
-        "[AI Services] Pay with Points - Receipt saved, navigating to /receipt?payment_id=" +
-          merchantOrderId,
-      );
-
-      setShowConfirmDialog(false);
-
-      // Navigate to receipt page
-      router.push(`/receipt?payment_id=${merchantOrderId}`);
-    } else {
-      toast.error("Failed to spend points");
-      setDialogLoading(false);
-    }
-  };
-
-  // Pay with Rozo Wallet (Stellar USDC)
-  // Only shown when page is opened in Rozo Wallet mobile app
-  // Uses window.rozo provider for gasless USDC transfers
-
-  const generateBridgeAddress = async (
-    amount: string,
-  ): Promise<{
-    amount: string;
-    bridgeAddress: string;
-    memo: string;
-    receiverAddressContract?: string;
-    receiverMemoContract?: string;
-  }> => {
-    const payment = await createPayment({
-      appId: appId,
-      toAddress: toAddress,
-      toChain: baseUSDC.chainId,
-      toToken: baseUSDC.token,
-      toUnits: amount,
-      preferredChain: rozoStellarUSDC.chainId,
-      preferredTokenAddress: rozoStellarUSDC.token,
-      metadata: metadata as any,
-      title: `Pay for ${service?.name}`,
-    });
-
-    if (
-      !payment.source.receiverAddress ||
-      !payment.source.amount ||
-      !payment.source.receiverMemo
-    ) {
-      throw new Error("Failed to generate bridge address");
-    }
-
-    return {
-      amount: payment.source.amount,
-      bridgeAddress: payment.source.receiverAddress,
-      memo: payment.source.receiverMemo,
-      receiverAddressContract: payment.source.receiverAddressContract,
-      receiverMemoContract: payment.source.receiverMemoContract,
-    };
-  };
-
-  const handlePayWithRozoWallet = async () => {
-    if (!service || !validateEmailInput()) return;
-
-    try {
-      setIsRozoWalletPaymentLoading(true);
-
-      if (typeof service.price_usd !== "number") {
-        toast.error("Price unavailable for this service");
-        return;
-      }
-      const usdAmount = service.price_usd.toString();
-
-      const { amount, receiverAddressContract, receiverMemoContract } =
-        await generateBridgeAddress(usdAmount);
-
-      const result = await rozoWalletTransfer(
-        amount,
-        receiverAddressContract,
-        receiverMemoContract,
-      );
-
-      if (result.hash) {
-        // Store receipt data
-        const receiptData = {
-          from_address: rozoWalletAddress || "",
-          to_handle: service.id,
-          amount_usd_cents: priceUsd * 100,
-          amount_local: priceUsd,
-          currency_local: "USD",
-          timestamp: Date.now(),
-          order_id: merchantOrderId,
-          about: `Pay for ${service.name}`,
-          service_name: service.name,
-          service_domain: service.id,
-          is_using_points: false,
-        };
-
-        console.log(
-          "[AI Services] Pay with Rozo Wallet - About to save receipt:",
-          {
-            merchantOrderId,
-            receiptData,
-          },
-        );
-        savePaymentReceipt(merchantOrderId, receiptData);
-        console.log(
-          "[AI Services] Pay with Rozo Wallet - Receipt saved, navigating to /receipt?payment_id=" +
-            merchantOrderId,
-        );
-
-        toast.success(`Payment successful to ${service.name}!`);
-        router.push(`/receipt?payment_id=${merchantOrderId}`);
-      }
-    } catch (error: unknown) {
-      console.error("Rozo Wallet payment error:", error);
-
-      if (isUserCancellation(error)) {
-        toast.error("Payment cancelled");
-        return;
-      }
-
-      if (isRozoProviderError(error)) {
-        toast.error(formatRozoErrorMessage(error));
-        return;
-      }
-
-      const fallback =
-        error instanceof Error ? error.message : "Payment failed. Please try again.";
-      toast.error(fallback);
-    } finally {
-      setIsRozoWalletPaymentLoading(false);
-    }
   };
 
   const handleShare = () => {
@@ -470,47 +187,6 @@ export default function AIServiceDetailPage() {
     hasAutoOpenedIntercomRef.current = true;
     openIntercomWithMessage();
   }, [service?.id, openIntercomWithMessage]);
-
-  const handlePaymentCompleted = (_args: PaymentCompletedEvent) => {
-    if (!service) return;
-
-    toast.success(`Payment successful to ${service.name}!`, {
-      description:
-        "Your payment has been processed successfully. Redirecting to receipt...",
-      duration: 2000,
-    });
-
-    // Store payment data in localStorage for receipt page
-    const receiptData: PaymentData = {
-      from_address: address || "",
-      to_handle: service.id,
-      amount_usd_cents: priceUsd * 100,
-      amount_local: priceUsd,
-      currency_local: "USD",
-      timestamp: Date.now(),
-      order_id: merchantOrderId,
-      about: `Pay for ${service.name}`,
-      service_name: service.name,
-      service_domain: service.id,
-      is_using_points: false,
-    };
-
-    console.log("[AI Services] Pay with Crypto - About to save receipt:", {
-      merchantOrderId,
-      receiptData,
-    });
-    savePaymentReceipt(merchantOrderId, receiptData);
-    console.log(
-      "[AI Services] Pay with Crypto - Receipt saved, navigating to /receipt?payment_id=" +
-        merchantOrderId,
-    );
-
-    // Prefetch and navigate to receipt page
-    router.prefetch("/receipt");
-    setTimeout(() => {
-      router.push(`/receipt?payment_id=${merchantOrderId}`);
-    }, 1000);
-  };
 
   if (loading) {
     return (
@@ -718,125 +394,32 @@ export default function AIServiceDetailPage() {
                 </div>
 
                 {/* Payment Buttons - Conditional based on Rozo Wallet availability */}
-                {!service.sold_out &&
-                  (isRozoWalletAvailable && isRozoWalletConnected ? (
+                {!service.sold_out && (
+                  isRozoWalletAvailable && isRozoWalletConnected ? (
                     // Pay with Rozo Wallet (Stellar USDC) - REPLACES other payment methods
-                    <div className="space-y-2">
-                      {/* Balance Display */}
-                      {rozoWalletBalance && (
-                        <p className="text-xs text-muted-foreground text-center">
-                          Rozo Wallet Balance: {rozoWalletBalance} (Stellar)
-                        </p>
-                      )}
-
-                      {/* Pay with Rozo Wallet Button */}
-                      <Button
-                        variant="default"
-                        className="w-full h-11 sm:h-12 cursor-pointer font-semibold text-sm sm:text-base"
-                        onClick={handlePayWithRozoWallet}
-                        disabled={isRozoWalletPaymentLoading}
-                        size="lg"
-                      >
-                        {isRozoWalletPaymentLoading ? (
-                          <>
-                            <Wallet className="mr-2 size-4 animate-pulse" />
-                            Processing Payment...
-                          </>
-                        ) : (
-                          <>
-                            <Wallet className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-                            Pay {hasPrice
-                              ? `$${service.price_usd}`
-                              : "N/A"}{" "}
-                            with Rozo Wallet
-                          </>
-                        )}
-                      </Button>
-                    </div>
+                    <AiServiceDappPayment
+                      service={service}
+                      merchantOrderId={merchantOrderId}
+                      userEmail={userEmail}
+                      appId={APP_ID}
+                      validateEmailInput={validateEmailInput}
+                    />
                   ) : (
-                    <>
-                      {/* Original Payment Buttons - ONLY shown when Rozo Wallet NOT available */}
-
-                      {/* Intent SDK for non mini app */}
-                      <RozoPayButton.Custom
-                        resetOnSuccess
-                        appId={appId}
-                        intent={`Pay for ${service.name}`}
-                        toAddress={toAddress}
-                        toChain={baseUSDC.chainId}
-                        toToken={baseUSDC.token}
-                        {...(service.price_usd && {
-                          toUnits: service.price_usd.toString(),
-                        })}
-                        metadata={metadata as any}
-                        onPaymentStarted={() => {
-                          setPaymentLoading(true);
-                        }}
-                        onPaymentCompleted={handlePaymentCompleted}
-                      >
-                        {({ show }) => (
-                          <div className="m-auto flex w-full flex-col gap-2">
-                            <Button
-                              className="w-full h-11 sm:h-12 text-sm sm:text-base font-semibold"
-                              size={"lg"}
-                              onClick={() => {
-                                if (!validateEmailInput()) {
-                                  return;
-                                }
-                                show();
-                              }}
-                              disabled={paymentLoading}
-                            >
-                              {paymentLoading ? (
-                                <>
-                                  <Wallet className="h-4 w-4 sm:h-5 sm:w-5 animate-pulse" />
-                                  Processing Payment...
-                                </>
-                              ) : (
-                                <>
-                                  <CreditCard className="h-4 w-4 sm:h-5 sm:w-5" />
-                                  Pay with Crypto
-                                </>
-                              )}
-                            </Button>
-                          </div>
-                        )}
-                      </RozoPayButton.Custom>
-
-                      {/* Pay with Points Button */}
-                      {points > 0 && (
-                        <div className="space-y-2">
-                          <Button
-                            className="w-full h-11 sm:h-12 text-sm sm:text-base font-semibold"
-                            size={"lg"}
-                            onClick={handlePayWithPoints}
-                            variant="outline"
-                            disabled={!hasPrice || points < priceUsd}
-                          >
-                            <Coins className="h-4 w-4 sm:h-5 sm:w-5" />
-                            Pay with{" "}
-                            {new Intl.NumberFormat("en-US", {
-                              style: "decimal",
-                              minimumFractionDigits: 0,
-                              maximumFractionDigits: 0,
-                            }).format(priceUsd * 100)}{" "}
-                            Points
-                          </Button>
-                          <div className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1">
-                            Available Points:{" "}
-                            {Number((points ?? 0) * 100).toFixed(2)} pts
-                            <CustomTooltip
-                              content="Explore all the benefits of Rozo. Rozo points are the rewards for your purchases."
-                              position="top"
-                              className="w-48 sm:w-[20rem] ml-1.5"
-                            >
-                              <HelpCircle className="ml-3 size-3 cursor-help text-muted-foreground hover:text-foreground transition-colors" />
-                            </CustomTooltip>
-                          </div>
-                        </div>
-                      )}
-                    </>
-                  ))}
+                    // Original Payment Buttons - ONLY shown when Rozo Wallet NOT available,
+                    // and only in discovery mode (not loaded inside the Rozo Wallet dapp webview)
+                    !isDapp && (
+                      <AiServiceDiscoveryPayment
+                        service={service}
+                        merchantOrderId={merchantOrderId}
+                        userEmail={userEmail}
+                        appId={APP_ID}
+                        validateEmailInput={validateEmailInput}
+                        paymentLoading={paymentLoading}
+                        setPaymentLoading={setPaymentLoading}
+                      />
+                    )
+                  )
+                )}
               </>
             )}
 
@@ -852,92 +435,6 @@ export default function AIServiceDetailPage() {
           <ContactSupport />
         </CardContent>
       </Card>
-
-      {/* Pay with Points Confirmation Dialog */}
-      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Confirm Payment with Points</DialogTitle>
-            <DialogDescription>
-              You are about to pay for{" "}
-              <span className="font-medium text-foreground">
-                {service?.name}
-              </span>{" "}
-              using your Rozo Points.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-4 py-4">
-            <div className="bg-muted/50 rounded-lg p-4 space-y-2">
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">
-                  Points to be used:
-                </span>
-                <span className="font-semibold text-foreground">
-                  {service &&
-                    new Intl.NumberFormat("en-US", {
-                      style: "decimal",
-                      minimumFractionDigits: 0,
-                      maximumFractionDigits: 0,
-                    }).format(priceUsd * 100)}{" "}
-                  pts
-                </span>
-              </div>
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">
-                  Available Points:
-                </span>
-                <span className="font-medium text-muted-foreground">
-                  {Number((points ?? 0) * 100).toFixed(2)} pts
-                </span>
-              </div>
-              <div className="h-px bg-border my-2" />
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">
-                  Remaining Points:
-                </span>
-                <span className="font-semibold text-foreground">
-                  {service &&
-                    new Intl.NumberFormat("en-US", {
-                      style: "decimal",
-                      minimumFractionDigits: 0,
-                      maximumFractionDigits: 0,
-                    }).format((points - priceUsd) * 100)}{" "}
-                  pts
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <DialogFooter className="flex-col sm:flex-row gap-2">
-            <Button
-              variant="outline"
-              onClick={() => setShowConfirmDialog(false)}
-              disabled={dialogLoading}
-              className="w-full sm:w-auto"
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={confirmPaymentWithPoints}
-              disabled={dialogLoading}
-              className="w-full sm:w-auto"
-            >
-              {dialogLoading ? (
-                <>
-                  <Wallet className="size-4 animate-pulse mr-2" />
-                  Processing...
-                </>
-              ) : (
-                <>
-                  <Coins className="size-4 mr-2" />
-                  Confirm Payment
-                </>
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }

--- a/src/app/ai-services/page.tsx
+++ b/src/app/ai-services/page.tsx
@@ -1,10 +1,38 @@
-"use client";
-
-import { DappContent } from "@/components/dapp/dapp-content";
+import { DiscoveryDappContent } from "@/components/dapp/discovery-dapp-content";
+import { getAllAiServices } from "@/lib/ai-services";
+import { getAllRestaurants } from "@/lib/restaurants";
+import { VISIBLE_HANDLES } from "@/shared";
 import { Binoculars } from "lucide-react";
 
-export default function DappPage() {
+export default function AiServicesPage() {
+  const restaurants = getAllRestaurants()
+    .filter((location) => VISIBLE_HANDLES.includes(location.handle))
+    .map((location) => ({
+      _id: location._id,
+      name: location.name,
+      handle: location.handle,
+      currency: location.currency,
+      formatted: location.formatted,
+      logo_url: location.logo_url,
+      cashback_rate: location.cashback_rate,
+      price: location.price ?? "",
+    }));
+
+  const aiServices = getAllAiServices().map((service) => ({
+    id: service.id,
+    name: service.name,
+    description: service.description,
+    price_usd: service.price_usd,
+    original_price_usd: service.original_price_usd,
+    logoUrl: service.logoUrl,
+  }));
+
   return (
-    <DappContent title="Discovery" icon={<Binoculars className="size-6" />} />
+    <DiscoveryDappContent
+      title="Discovery"
+      icon={<Binoculars className="size-6" />}
+      restaurants={restaurants}
+      aiServices={aiServices}
+    />
   );
 }

--- a/src/app/dapp/page.tsx
+++ b/src/app/dapp/page.tsx
@@ -1,7 +1,36 @@
-"use client";
-
 import { DappContent } from "@/components/dapp/dapp-content";
+import { getAllAiServices } from "@/lib/ai-services";
+import { getAllRestaurants } from "@/lib/restaurants";
+import { VISIBLE_HANDLES } from "@/shared";
 
 export default function DappPage() {
-  return <DappContent isDapp={true} />;
+  const restaurants = getAllRestaurants()
+    .filter((location) => VISIBLE_HANDLES.includes(location.handle))
+    .map((location) => ({
+      _id: location._id,
+      name: location.name,
+      handle: location.handle,
+      currency: location.currency,
+      formatted: location.formatted,
+      logo_url: location.logo_url,
+      cashback_rate: location.cashback_rate,
+      price: location.price ?? "",
+    }));
+
+  const aiServices = getAllAiServices().map((service) => ({
+    id: service.id,
+    name: service.name,
+    description: service.description,
+    price_usd: service.price_usd,
+    original_price_usd: service.original_price_usd,
+    logoUrl: service.logoUrl,
+  }));
+
+  return (
+    <DappContent
+      isDapp={true}
+      restaurants={restaurants}
+      aiServices={aiServices}
+    />
+  );
 }

--- a/src/app/discovery/page.tsx
+++ b/src/app/discovery/page.tsx
@@ -1,10 +1,38 @@
-"use client";
-
-import { DappContent } from "@/components/dapp/dapp-content";
+import { DiscoveryDappContent } from "@/components/dapp/discovery-dapp-content";
+import { getAllAiServices } from "@/lib/ai-services";
+import { getAllRestaurants } from "@/lib/restaurants";
+import { VISIBLE_HANDLES } from "@/shared";
 import { Binoculars } from "lucide-react";
 
-export default function DappPage() {
+export default function DiscoveryPage() {
+  const restaurants = getAllRestaurants()
+    .filter((location) => VISIBLE_HANDLES.includes(location.handle))
+    .map((location) => ({
+      _id: location._id,
+      name: location.name,
+      handle: location.handle,
+      currency: location.currency,
+      formatted: location.formatted,
+      logo_url: location.logo_url,
+      cashback_rate: location.cashback_rate,
+      price: location.price ?? "",
+    }));
+
+  const aiServices = getAllAiServices().map((service) => ({
+    id: service.id,
+    name: service.name,
+    description: service.description,
+    price_usd: service.price_usd,
+    original_price_usd: service.original_price_usd,
+    logoUrl: service.logoUrl,
+  }));
+
   return (
-    <DappContent title="Discovery" icon={<Binoculars className="size-6" />} />
+    <DiscoveryDappContent
+      title="Discovery"
+      icon={<Binoculars className="size-6" />}
+      restaurants={restaurants}
+      aiServices={aiServices}
+    />
   );
 }

--- a/src/app/restaurant/[id]/page.tsx
+++ b/src/app/restaurant/[id]/page.tsx
@@ -2,29 +2,15 @@
 
 import { ContactSupport } from "@/components/contact-support";
 import { PageHeader } from "@/components/page-header";
+import { RestaurantDappPayment } from "@/components/restaurant/restaurant-dapp-payment";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { CustomTooltip } from "@/components/ui/custom-tooltip";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { useBookmarks } from "@/contexts/BookmarkContext";
-import { useRozoPointAPI } from "@/hooks/useRozoPointAPI";
 import { useRozoWallet } from "@/hooks/useRozoWallet";
-import {
-  formatRozoErrorMessage,
-  isRozoProviderError,
-  isUserCancellation,
-} from "@/lib/rozo-errors";
 import {
   convertToUSD,
   EXCHANGE_RATES,
@@ -35,33 +21,26 @@ import { getRestaurantById } from "@/lib/restaurants";
 import { Restaurant } from "@/types/restaurant";
 import { useComposeCast, useIsInMiniApp } from "@coinbase/onchainkit/minikit";
 import {
-  baseUSDC,
-  createPayment,
-  PaymentCompletedEvent,
-  rozoStellarUSDC,
-} from "@rozoai/intent-common";
-import { RozoPayButton, useRozoPay, useRozoPayUI } from "@rozoai/intent-pay";
-
-import { PaymentData } from "@/app/receipt/receipt-content";
-import { savePaymentReceipt } from "@/lib/payment-storage";
-import { useAppKitAccount } from "@reown/appkit/react";
-import {
   BadgePercent,
   Bookmark,
   ChevronDown,
   ChevronUp,
-  Coins,
-  CreditCard,
-  HelpCircle,
-  Loader2,
   MapPin,
   Share,
-  Wallet,
 } from "lucide-react";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useMemo } from "react";
 import { toast } from "sonner";
+
+const RestaurantDiscoveryPayment = dynamic(
+  () =>
+    import("@/components/restaurant/restaurant-discovery-payment").then(
+      (m) => m.RestaurantDiscoveryPayment,
+    ),
+  { ssr: false },
+);
 
 export default function RestaurantDetailPage() {
   const searchParams = useSearchParams();
@@ -69,10 +48,6 @@ export default function RestaurantDetailPage() {
   const params = useParams();
   const router = useRouter();
   const restaurantId = params.id as string;
-  const { resetPayment } = useRozoPayUI();
-  const { paymentState } = useRozoPay();
-  const { getPoints, spendPoints } = useRozoPointAPI();
-  const { address, isConnected } = useAppKitAccount();
   const { isInMiniApp } = useIsInMiniApp();
   const { composeCast } = useComposeCast();
   const { isBookmarked, toggleBookmark } = useBookmarks();
@@ -80,11 +55,6 @@ export default function RestaurantDetailPage() {
     isAvailable: isRozoWalletAvailable,
     isConnected: isRozoWalletConnected,
     walletAddress: rozoWalletAddress,
-    balance: rozoWalletBalance,
-    balanceUsd: rozoWalletBalanceUsd,
-    isLoading: rozoWalletLoading,
-    transferUSDC: rozoWalletTransfer,
-    refreshData: refreshRozoWallet,
   } = useRozoWallet();
 
   const restaurant = React.useMemo(
@@ -92,34 +62,19 @@ export default function RestaurantDetailPage() {
     [restaurantId],
   );
   const [loading, setLoading] = React.useState(false);
-  const [error, setError] = React.useState<string | null>(
+  const [error] = React.useState<string | null>(
     restaurant ? null : restaurantId ? "Restaurant not found" : null,
   );
-  const [paymentLoading, setPaymentLoading] = React.useState(false);
   const [paymentAmount, setPaymentAmount] = React.useState<string>(() => {
     const price = restaurant?.price && !isNaN(Number(restaurant.price)) ? Number(restaurant.price) : 0;
     return price.toFixed(2);
   });
-  const [points, setPoints] = React.useState(0);
-  const [pointsLoading, setPointsLoading] = React.useState(false);
-  const [showConfirmDialog, setShowConfirmDialog] = React.useState(false);
-  const [dialogLoading, setDialogLoading] = React.useState(false);
   const [showFullAddress, setShowFullAddress] = React.useState(false);
-  const [isRozoWalletPaymentLoading, setIsRozoWalletPaymentLoading] =
-    React.useState(false);
-  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const lastResetAmountRef = useRef<string>("");
-  const [appId, setAppId] = React.useState<string>(
+  const [appId] = React.useState<string>(
     () => `rozoRewardsBNBStellarMP-${restaurant?.handle || ""}`,
   );
 
-  // Prefer Rozo Wallet account when available, otherwise fall back to EVM account
-  const activeAddress =
-    (isRozoWalletConnected && rozoWalletAddress) ||
-    (isConnected && address) ||
-    "";
-
-  const [merchantOrderId, setMerchantOrderId] = React.useState<string>(
+  const [merchantOrderId] = React.useState<string>(
     `${restaurant?.handle.toUpperCase()}-${new Date().getTime()}`,
   );
   const receiptUrl = `https://ns.rozo.ai/payment/success?order_id=${merchantOrderId}`;
@@ -165,195 +120,11 @@ export default function RestaurantDetailPage() {
     if (!restaurantId || !restaurant) return;
 
     router.prefetch("/receipt");
-
-    const price =
-      restaurant.price && !isNaN(Number(restaurant.price))
-        ? Number(restaurant.price)
-        : 0;
-    const displayCurrency = restaurant.currency || "USD";
-    const usdAmount = convertToUSD(price.toFixed(2), displayCurrency);
-
-    if (!isDapp) {
-      resetPayment({
-        appId: appId,
-        intent: `${restaurant.name} - ${displayCurrency} ${price.toFixed(2)}`,
-        toAddress: restaurant.payTo ?? "0x5772FBe7a7817ef7F586215CA8b23b8dD22C8897",
-        toChain: baseUSDC.chainId,
-        toToken: baseUSDC.token as `0x${string}`,
-        toUnits: usdAmount,
-        metadata: generateMetadata(price.toFixed(2), displayCurrency) as any,
-      });
-    }
-
-    lastResetAmountRef.current = price.toFixed(2);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [restaurantId]);
-
-  useEffect(() => {
-    const fetchPoints = async () => {
-      if (!address) return;
-
-      setPointsLoading(true);
-      const points = await getPoints(address);
-      setPoints(points / 100);
-      setPointsLoading(false);
-    };
-    fetchPoints();
-  }, [isConnected, address]);
-
-  // Cleanup timer on unmount
-  useEffect(() => {
-    return () => {
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current);
-      }
-    };
-  }, []);
-
-  const [isDebouncing, setIsDebouncing] = React.useState(false);
+  }, [restaurantId, restaurant, router]);
 
   const handleAmountChange = (value: string) => {
     if (!restaurant) return;
     setPaymentAmount(value);
-    setIsDebouncing(true);
-
-    // Clear the previous timer if it exists
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-    }
-
-    // Set a new timer
-    debounceTimerRef.current = setTimeout(async () => {
-      const displayCurrency = getDisplayCurrency(restaurant.currency);
-      const usdAmount = convertToUSD(value, displayCurrency);
-
-      const appId = `rozoRewardsBNBStellarMP-${restaurant.handle || ""}`;
-      setAppId(appId);
-
-      if (
-        !(
-          typeof window !== "undefined" &&
-          new URLSearchParams(window.location.search).get("dapp") === "true"
-        )
-      ) {
-        await resetPayment({
-          appId: appId,
-          intent: `Pay for ${restaurant.name} - ${displayCurrency}${value} ($${usdAmount})`,
-          toAddress: "0x5772FBe7a7817ef7F586215CA8b23b8dD22C8897",
-          toChain: baseUSDC.chainId,
-          toToken: baseUSDC.token as `0x${string}`,
-          toUnits: usdAmount, // Use USD amount for payment processing
-          metadata: generateMetadata(value, displayCurrency) as any,
-        });
-      }
-      setIsDebouncing(false);
-      debounceTimerRef.current = null;
-    }, 500);
-  };
-
-  const handlePayWithPoints = () => {
-    setShowConfirmDialog(true);
-  };
-
-  const confirmPaymentWithPoints = async () => {
-    try {
-      if (!address || !restaurant || !paymentAmount) return;
-
-      setDialogLoading(true);
-
-      const displayCurrency = getDisplayCurrency(restaurant?.currency);
-      const usdAmount = convertToUSD(paymentAmount, displayCurrency);
-
-      const paymentData = {
-        from_address: address,
-        to_handle:
-          restaurant.handle ||
-          restaurant.name.toLowerCase().replace(/\s+/g, ""),
-        amount_usd_cents: parseFloat(usdAmount) * 100,
-        amount_local: parseFloat(paymentAmount),
-        currency_local: displayCurrency,
-        timestamp: Date.now(),
-        order_id: merchantOrderId,
-        about: `Pay for ${restaurant.name} - $${paymentAmount}`,
-      };
-      const response = await spendPoints(paymentData);
-
-      if (response && response.status === "success") {
-        // Store payment data in localStorage for receipt page
-        const receiptData: PaymentData = {
-          ...response.data,
-          restaurant_name: restaurant.name,
-          restaurant_address: restaurant.address_line1,
-          is_using_points: true,
-        };
-
-        console.log("[Restaurant] Pay with Points - About to save receipt:", {
-          merchantOrderId,
-          receiptData,
-        });
-        savePaymentReceipt(merchantOrderId, receiptData);
-        console.log(
-          "[Restaurant] Pay with Points - Receipt saved, navigating to /receipt?payment_id=" +
-            merchantOrderId,
-        );
-
-        setShowConfirmDialog(false);
-        toast.success("Points spent successfully");
-        // Navigate to receipt page
-        router.push(`/receipt?payment_id=${merchantOrderId}`);
-      } else {
-        toast.error("Failed to spend points");
-        setDialogLoading(false);
-      }
-    } catch {
-      toast.error("Failed to spend points");
-      setDialogLoading(false);
-    }
-  };
-
-  // Pay with Rozo Wallet (Stellar USDC)
-  // Only shown when page is opened in Rozo Wallet mobile app
-  // Uses window.rozo provider for gasless USDC transfers
-  const generateBridgeAddress = async (params: {
-    amountUsd: string;
-    amountLocal: string;
-    currencyLocal: string;
-  }): Promise<{
-    amount: string;
-    bridgeAddress: string;
-    memo: string;
-    receiverAddressContract?: string;
-    receiverMemoContract?: string;
-  }> => {
-    const displayCurrency = getDisplayCurrency(params.currencyLocal);
-
-    const payment = await createPayment({
-      appId: appId,
-      toAddress: toAddress,
-      toChain: baseUSDC.chainId,
-      toToken: baseUSDC.token,
-      toUnits: params.amountUsd,
-      preferredChain: rozoStellarUSDC.chainId,
-      preferredTokenAddress: rozoStellarUSDC.token,
-      metadata: generateMetadata(params.amountLocal, displayCurrency) as any,
-      title: `Pay for ${restaurant?.name} - ${displayCurrency} ${params.amountLocal} ($${params.amountUsd})`,
-    });
-
-    if (
-      !payment.source.receiverAddress ||
-      !payment.source.amount ||
-      !payment.source.receiverMemo
-    ) {
-      throw new Error("Failed to generate bridge address");
-    }
-
-    return {
-      amount: payment.source.amount,
-      bridgeAddress: payment.source.receiverAddress,
-      memo: payment.source.receiverMemo,
-      receiverAddressContract: payment.source.receiverAddressContract,
-      receiverMemoContract: payment.source.receiverMemoContract,
-    };
   };
 
   const handleShare = () => {
@@ -400,139 +171,6 @@ export default function RestaurantDetailPage() {
           : "Added to bookmarks",
       );
     }
-  };
-
-  const handleClearPayment = () => {
-    setPaymentAmount("");
-    setPaymentLoading(false);
-  };
-
-  const handlePayWithRozoWallet = async () => {
-    if (!restaurant || !paymentAmount) return;
-
-    try {
-      setIsRozoWalletPaymentLoading(true);
-
-      const displayCurrency = getDisplayCurrency(restaurant.currency);
-      const usdAmount = convertToUSD(paymentAmount, displayCurrency);
-
-      // Transfer USDC on Stellar network
-      const { amount, receiverAddressContract, receiverMemoContract } =
-        await generateBridgeAddress({
-          amountUsd: usdAmount,
-          amountLocal: paymentAmount,
-          currencyLocal: displayCurrency,
-        });
-
-      const result = await rozoWalletTransfer(
-        amount,
-        receiverAddressContract,
-        receiverMemoContract,
-      );
-
-      if (result.hash) {
-        // Store receipt data
-        const receiptData: PaymentData = {
-          from_address: rozoWalletAddress || "",
-          to_handle:
-            restaurant.handle ||
-            restaurant.name.toLowerCase().replace(/\s+/g, ""),
-          amount_usd_cents: parseFloat(usdAmount) * 100,
-          amount_local: parseFloat(paymentAmount),
-          currency_local: displayCurrency,
-          timestamp: Date.now(),
-          order_id: merchantOrderId,
-          about: `Pay for ${restaurant.name} - ${displayCurrency} ${paymentAmount}`,
-          restaurant_name: restaurant.name,
-          restaurant_address: restaurant.address_line1,
-          is_using_points: false,
-        };
-
-        console.log(
-          "[Restaurant] Pay with Rozo Wallet - About to save receipt:",
-          {
-            merchantOrderId,
-            receiptData,
-          },
-        );
-        savePaymentReceipt(merchantOrderId, receiptData);
-        console.log(
-          "[Restaurant] Pay with Rozo Wallet - Receipt saved, navigating to /receipt?payment_id=" +
-            merchantOrderId +
-            "&withRozoWallet=true",
-        );
-
-        toast.success(`Payment successful to ${restaurant.name}!`);
-        router.push(
-          `/receipt?payment_id=${merchantOrderId}&withRozoWallet=true`,
-        );
-      }
-    } catch (error: unknown) {
-      console.error("Rozo Wallet payment error:", error);
-
-      if (isUserCancellation(error)) {
-        toast.error("Payment cancelled");
-        return;
-      }
-
-      if (isRozoProviderError(error)) {
-        toast.error(formatRozoErrorMessage(error));
-        return;
-      }
-
-      const fallback =
-        error instanceof Error ? error.message : "Payment failed. Please try again.";
-      toast.error(fallback);
-    } finally {
-      setIsRozoWalletPaymentLoading(false);
-    }
-  };
-
-  const handlePaymentCompleted = (args?: PaymentCompletedEvent) => {
-    console.log("[Restaurant] Payment completed:", args);
-
-    if (!restaurant) return;
-
-    toast.success(`Payment successful to ${restaurant.name}!`, {
-      description:
-        "Your payment has been processed successfully. Redirecting to receipt...",
-      duration: 2000,
-    });
-
-    // Store payment data in sessionStorage for receipt page
-    const displayCurrency = getDisplayCurrency(restaurant?.currency);
-    const usdAmount = convertToUSD(paymentAmount, displayCurrency);
-
-    const receiptData: PaymentData = {
-      from_address: address || "",
-      to_handle:
-        restaurant.handle || restaurant.name.toLowerCase().replace(/\s+/g, ""),
-      amount_usd_cents: parseFloat(usdAmount) * 100,
-      amount_local: parseFloat(paymentAmount),
-      currency_local: displayCurrency,
-      timestamp: Date.now(),
-      order_id: merchantOrderId,
-      about: `Pay for ${restaurant.name} - ${displayCurrency} ${paymentAmount}`,
-      restaurant_name: restaurant.name,
-      restaurant_address: restaurant.address_line1,
-      is_using_points: false,
-    };
-
-    console.log("[Restaurant] Pay with Crypto - About to save receipt:", {
-      merchantOrderId,
-      receiptData,
-    });
-    savePaymentReceipt(merchantOrderId, receiptData);
-    console.log(
-      "[Restaurant] Pay with Crypto - Receipt saved, navigating to /receipt?payment_id=" +
-        merchantOrderId,
-    );
-
-    setTimeout(() => {
-      handleClearPayment();
-      setLoading(false);
-      router.push(`/receipt?payment_id=${merchantOrderId}`);
-    }, 1000);
   };
 
   if (loading) {
@@ -595,7 +233,7 @@ export default function RestaurantDetailPage() {
         <PageHeader
           title="Back to DApps"
           isBackButton
-          paymentHistoryAddress={activeAddress}
+          paymentHistoryAddress={rozoWalletAddress || ""}
         />
       ) : (
         <PageHeader title="Back to Lifestyle" isBackButton />
@@ -742,183 +380,27 @@ export default function RestaurantDetailPage() {
                 {/* Payment Buttons - Conditional based on Rozo Wallet availability */}
                 {isRozoWalletAvailable && isRozoWalletConnected ? (
                   // Pay with Rozo Wallet (Stellar USDC) - REPLACES other payment methods
-                  <div className="space-y-2">
-                    {/* Balance Display */}
-                    {rozoWalletBalance && (
-                      <p className="text-xs text-muted-foreground text-center">
-                        Rozo Wallet Balance: {rozoWalletBalance}
-                      </p>
-                    )}
-
-                    {/* Pay with Rozo Wallet Button */}
-                    <Button
-                      variant="default"
-                      className="w-full h-11 sm:h-12 cursor-pointer font-semibold text-sm sm:text-base"
-                      onClick={handlePayWithRozoWallet}
-                      disabled={
-                        isRozoWalletPaymentLoading ||
-                        !paymentAmount ||
-                        parseFloat(paymentAmount) <= 0 ||
-                        isNaN(parseFloat(paymentAmount)) ||
-                        rozoWalletLoading ||
-                        (rozoWalletBalanceUsd !== null &&
-                          rozoWalletBalanceUsd <= 0)
-                      }
-                      size="lg"
-                    >
-                      {isRozoWalletPaymentLoading ? (
-                        <Loader2 className="mr-2 size-4 animate-spin" />
-                      ) : (
-                        <Wallet className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-                      )}
-                      {rozoWalletBalanceUsd !== null &&
-                      rozoWalletBalanceUsd > 0 ? (
-                        <>
-                          Pay $
-                          {isNaN(
-                            parseFloat(
-                              convertToUSD(
-                                paymentAmount || "0",
-                                getDisplayCurrency(restaurant?.currency),
-                              ),
-                            ),
-                          )
-                            ? "0.00"
-                            : convertToUSD(
-                                paymentAmount || "0",
-                                getDisplayCurrency(restaurant?.currency),
-                              )}{" "}
-                          with Rozo Wallet
-                        </>
-                      ) : (
-                        "Insufficient Rozo Wallet Balance"
-                      )}
-                    </Button>
-                  </div>
+                  <RestaurantDappPayment
+                    restaurant={restaurant}
+                    paymentAmount={paymentAmount}
+                    appId={appId}
+                    merchantOrderId={merchantOrderId}
+                  />
                 ) : (
-                  <>
-                    {/* Original Payment Buttons - ONLY shown when Rozo Wallet NOT available */}
-
-                    {/* Payment Button */}
-                    <RozoPayButton.Custom
-                      resetOnSuccess
+                  // Original Payment Buttons - ONLY shown when Rozo Wallet NOT available,
+                  // and only in discovery mode (not loaded inside the Rozo Wallet dapp webview)
+                  !isDapp && (
+                    <RestaurantDiscoveryPayment
+                      restaurant={restaurant}
+                      paymentAmount={paymentAmount}
                       appId={appId}
+                      merchantOrderId={merchantOrderId}
                       toAddress={toAddress}
-                      toChain={baseUSDC.chainId}
-                      {...(paymentAmount && parseFloat(paymentAmount) > 0
-                        ? {
-                            toUnits: convertToUSD(
-                              paymentAmount,
-                              getDisplayCurrency(restaurant?.currency),
-                            ),
-                          }
-                        : {})}
-                      toToken={baseUSDC.token}
-                      intent={`Pay for ${restaurant.name} - ${getDisplayCurrency(
-                        restaurant?.currency,
-                      )} ${paymentAmount}`}
-                      onPaymentStarted={() => {
-                        setLoading(true);
-                        setPaymentLoading(true);
-                      }}
-                      onPaymentCompleted={(args: PaymentCompletedEvent) => {
-                        handlePaymentCompleted(args);
-                      }}
-                    >
-                      {({ show }) => {
-                        const usdAmount = convertToUSD(
-                          paymentAmount,
-                          getDisplayCurrency(restaurant?.currency),
-                        );
-
-                        return (
-                          <Button
-                            variant="default"
-                            className="w-full h-11 sm:h-12 cursor-pointer font-semibold text-sm sm:text-base"
-                            onClick={show}
-                            disabled={
-                              isDebouncing ||
-                              loading ||
-                              !paymentAmount ||
-                              parseFloat(paymentAmount) <= 0 ||
-                              isNaN(parseFloat(paymentAmount)) ||
-                              paymentState !== "preview"
-                            }
-                            size="lg"
-                          >
-                            {loading ? (
-                              <Loader2 className="mr-2 size-4 animate-spin" />
-                            ) : (
-                              <CreditCard className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-                            )}
-                            Pay $
-                            {isNaN(parseFloat(usdAmount)) ? "0.00" : usdAmount}{" "}
-                            with Crypto
-                          </Button>
-                        );
-                      }}
-                    </RozoPayButton.Custom>
-
-                    {/* Pay with Points Button */}
-                    {points > 0 && (
-                      <div className="space-y-2">
-                        <Button
-                          className="w-full h-11 sm:h-12 text-sm sm:text-base font-semibold"
-                          size="lg"
-                          onClick={handlePayWithPoints}
-                          variant="outline"
-                          disabled={
-                            !paymentAmount ||
-                            parseFloat(paymentAmount) <= 0 ||
-                            isNaN(parseFloat(paymentAmount)) ||
-                            points <
-                              parseFloat(
-                                convertToUSD(
-                                  paymentAmount,
-                                  getDisplayCurrency(restaurant?.currency),
-                                ),
-                              )
-                          }
-                        >
-                          <Coins className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-                          Pay with{" "}
-                          {new Intl.NumberFormat("en-US", {
-                            style: "decimal",
-                            minimumFractionDigits: 0,
-                            maximumFractionDigits: 0,
-                          }).format(
-                            isNaN(
-                              parseFloat(
-                                convertToUSD(
-                                  paymentAmount || "0",
-                                  getDisplayCurrency(restaurant?.currency),
-                                ),
-                              ),
-                            )
-                              ? 0
-                              : parseFloat(
-                                  convertToUSD(
-                                    paymentAmount || "0",
-                                    getDisplayCurrency(restaurant?.currency),
-                                  ),
-                                ) * 100,
-                          )}{" "}
-                          Points
-                        </Button>
-                        <div className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1">
-                          Available Points:{" "}
-                          {Number((points ?? 0) * 100).toFixed(2)} pts
-                          <CustomTooltip
-                            content="Explore all the benefits of Rozo. Rozo points are the rewards for your purchases."
-                            position="top"
-                            className="w-48 sm:w-[20rem] ml-1.5"
-                          >
-                            <HelpCircle className="ml-3 size-3 cursor-help text-muted-foreground hover:text-foreground transition-colors" />
-                          </CustomTooltip>
-                        </div>
-                      </div>
-                    )}
-                  </>
+                      generateMetadata={generateMetadata}
+                      loading={loading}
+                      setLoading={setLoading}
+                    />
+                  )
                 )}
               </div>
             </div>
@@ -928,132 +410,6 @@ export default function RestaurantDetailPage() {
           <ContactSupport />
         </CardContent>
       </Card>
-
-      {/* Pay with Points Confirmation Dialog */}
-      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Confirm Payment with Points</DialogTitle>
-            <DialogDescription>
-              You are about to pay for{" "}
-              <span className="font-medium text-foreground">
-                {restaurant?.name}
-              </span>{" "}
-              using your Rozo Points.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-4 py-4">
-            <div className="bg-muted/50 rounded-lg p-4 space-y-2">
-              {getDisplayCurrency(restaurant?.currency) !== "USD" && (
-                <>
-                  <div className="flex justify-between items-center">
-                    <span className="text-sm text-muted-foreground">
-                      Amount ({getDisplayCurrency(restaurant?.currency)}):
-                    </span>
-                    <span className="font-medium text-foreground">
-                      {getDisplayCurrency(restaurant?.currency)} {paymentAmount}
-                    </span>
-                  </div>
-                  <div className="flex justify-between items-center">
-                    <span className="text-sm text-muted-foreground">
-                      USD Equivalent:
-                    </span>
-                    <span className="font-medium text-foreground">
-                      ${" "}
-                      {convertToUSD(
-                        paymentAmount,
-                        getDisplayCurrency(restaurant?.currency),
-                      )}
-                    </span>
-                  </div>
-                </>
-              )}
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">
-                  Points to be used:
-                </span>
-                <span className="font-semibold text-foreground">
-                  {paymentAmount &&
-                    new Intl.NumberFormat("en-US", {
-                      style: "decimal",
-                      minimumFractionDigits: 0,
-                      maximumFractionDigits: 0,
-                    }).format(
-                      parseFloat(
-                        convertToUSD(
-                          paymentAmount,
-                          getDisplayCurrency(restaurant?.currency),
-                        ),
-                      ) * 100,
-                    )}{" "}
-                  pts
-                </span>
-              </div>
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">
-                  Available Points:
-                </span>
-                <span className="font-medium text-muted-foreground">
-                  {Number((points ?? 0) * 100).toFixed(2)} pts{" "}
-                </span>
-              </div>
-              <div className="h-px bg-border my-2" />
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">
-                  Remaining Points:
-                </span>
-                <span className="font-semibold text-foreground">
-                  {paymentAmount &&
-                    new Intl.NumberFormat("en-US", {
-                      style: "decimal",
-                      minimumFractionDigits: 0,
-                      maximumFractionDigits: 0,
-                    }).format(
-                      (points -
-                        parseFloat(
-                          convertToUSD(
-                            paymentAmount,
-                            getDisplayCurrency(restaurant?.currency),
-                          ),
-                        )) *
-                        100,
-                    )}{" "}
-                  pts
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <DialogFooter className="flex-col sm:flex-row gap-2">
-            <Button
-              variant="outline"
-              onClick={() => setShowConfirmDialog(false)}
-              disabled={dialogLoading}
-              className="w-full sm:w-auto"
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={confirmPaymentWithPoints}
-              disabled={dialogLoading}
-              className="w-full sm:w-auto"
-            >
-              {dialogLoading ? (
-                <>
-                  <Wallet className="size-4 animate-pulse mr-2" />
-                  Processing...
-                </>
-              ) : (
-                <>
-                  <Coins className="size-4 mr-2" />
-                  Confirm Payment
-                </>
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }

--- a/src/components/ai-services/ai-service-dapp-payment.tsx
+++ b/src/components/ai-services/ai-service-dapp-payment.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useRozoWallet } from "@/hooks/useRozoWallet";
+import {
+  formatRozoErrorMessage,
+  isRozoProviderError,
+  isUserCancellation,
+} from "@/lib/rozo-errors";
+import { savePaymentReceipt } from "@/lib/payment-storage";
+import { getAiServiceById } from "@/lib/ai-services";
+import {
+  baseUSDC,
+  createPayment,
+  rozoStellarUSDC,
+} from "@rozoai/intent-common";
+import { Loader2, Wallet } from "lucide-react";
+import { useRouter } from "next/navigation";
+import React from "react";
+import { toast } from "sonner";
+
+const toAddress = "0x5772FBe7a7817ef7F586215CA8b23b8dD22C8897";
+
+interface AiServiceDappPaymentProps {
+  service: NonNullable<ReturnType<typeof getAiServiceById>>;
+  merchantOrderId: string;
+  userEmail: string;
+  appId: string;
+  validateEmailInput: () => boolean;
+}
+
+export function AiServiceDappPayment({
+  service,
+  merchantOrderId,
+  userEmail,
+  appId,
+  validateEmailInput,
+}: AiServiceDappPaymentProps) {
+  const router = useRouter();
+  const {
+    isAvailable: isRozoWalletAvailable,
+    isConnected: isRozoWalletConnected,
+    walletAddress: rozoWalletAddress,
+    balance: rozoWalletBalance,
+    transferUSDC: rozoWalletTransfer,
+  } = useRozoWallet();
+
+  const [isRozoWalletPaymentLoading, setIsRozoWalletPaymentLoading] =
+    React.useState(false);
+
+  const priceUsd = service?.price_usd ?? 0;
+  const hasPrice = typeof service?.price_usd === "number";
+  const receiptUrl = `https://ns.rozo.ai/payment/success?order_id=${merchantOrderId}`;
+
+  const generateMetadata = () => {
+    const baseMetadata = {
+      amount_local: service?.price_usd,
+      currency_local: "USD",
+      email: userEmail,
+      items: [
+        {
+          name: service?.name,
+          description: `${service?.price_usd ?? "N/A"} USD`,
+        },
+      ],
+    };
+
+    if (service?.id) {
+      return {
+        ...baseMetadata,
+        merchant_order_id: merchantOrderId,
+        ...(service?.sold_out ? { receiptUrl: receiptUrl } : {}),
+        items: [
+          ...baseMetadata.items,
+          {
+            name: "Order ID",
+            description: merchantOrderId,
+          },
+        ],
+      };
+    }
+
+    return baseMetadata;
+  };
+
+  // Pay with Rozo Wallet (Stellar USDC)
+  // Only shown when page is opened in Rozo Wallet mobile app
+  // Uses window.rozo provider for gasless USDC transfers
+  const generateBridgeAddress = async (
+    amount: string,
+  ): Promise<{
+    amount: string;
+    bridgeAddress: string;
+    memo: string;
+    receiverAddressContract?: string;
+    receiverMemoContract?: string;
+  }> => {
+    const payment = await createPayment({
+      appId: appId,
+      toAddress: toAddress,
+      toChain: baseUSDC.chainId,
+      toToken: baseUSDC.token,
+      toUnits: amount,
+      preferredChain: rozoStellarUSDC.chainId,
+      preferredTokenAddress: rozoStellarUSDC.token,
+      metadata: generateMetadata() as any,
+      title: `Pay for ${service?.name}`,
+    });
+
+    if (
+      !payment.source.receiverAddress ||
+      !payment.source.amount ||
+      !payment.source.receiverMemo
+    ) {
+      throw new Error("Failed to generate bridge address");
+    }
+
+    return {
+      amount: payment.source.amount,
+      bridgeAddress: payment.source.receiverAddress,
+      memo: payment.source.receiverMemo,
+      receiverAddressContract: payment.source.receiverAddressContract,
+      receiverMemoContract: payment.source.receiverMemoContract,
+    };
+  };
+
+  const handlePayWithRozoWallet = async () => {
+    if (!service || !validateEmailInput()) return;
+
+    try {
+      setIsRozoWalletPaymentLoading(true);
+
+      if (typeof service.price_usd !== "number") {
+        toast.error("Price unavailable for this service");
+        return;
+      }
+      const usdAmount = service.price_usd.toString();
+
+      const { amount, receiverAddressContract, receiverMemoContract } =
+        await generateBridgeAddress(usdAmount);
+
+      const result = await rozoWalletTransfer(
+        amount,
+        receiverAddressContract,
+        receiverMemoContract,
+      );
+
+      if (result.hash) {
+        // Store receipt data
+        const receiptData = {
+          from_address: rozoWalletAddress || "",
+          to_handle: service.id,
+          amount_usd_cents: priceUsd * 100,
+          amount_local: priceUsd,
+          currency_local: "USD",
+          timestamp: Date.now(),
+          order_id: merchantOrderId,
+          about: `Pay for ${service.name}`,
+          service_name: service.name,
+          service_domain: service.id,
+          is_using_points: false,
+        };
+
+        console.log(
+          "[AI Services] Pay with Rozo Wallet - About to save receipt:",
+          {
+            merchantOrderId,
+            receiptData,
+          },
+        );
+        savePaymentReceipt(merchantOrderId, receiptData);
+        console.log(
+          "[AI Services] Pay with Rozo Wallet - Receipt saved, navigating to /receipt?payment_id=" +
+            merchantOrderId,
+        );
+
+        toast.success(`Payment successful to ${service.name}!`);
+        router.push(`/receipt?payment_id=${merchantOrderId}`);
+      }
+    } catch (error: unknown) {
+      console.error("Rozo Wallet payment error:", error);
+
+      if (isUserCancellation(error)) {
+        toast.error("Payment cancelled");
+        return;
+      }
+
+      if (isRozoProviderError(error)) {
+        toast.error(formatRozoErrorMessage(error));
+        return;
+      }
+
+      const fallback =
+        error instanceof Error
+          ? error.message
+          : "Payment failed. Please try again.";
+      toast.error(fallback);
+    } finally {
+      setIsRozoWalletPaymentLoading(false);
+    }
+  };
+
+  if (!isRozoWalletAvailable || !isRozoWalletConnected) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* Balance Display */}
+      {rozoWalletBalance && (
+        <p className="text-xs text-muted-foreground text-center">
+          Rozo Wallet Balance: {rozoWalletBalance} (Stellar)
+        </p>
+      )}
+
+      {/* Pay with Rozo Wallet Button */}
+      <Button
+        variant="default"
+        className="w-full h-11 sm:h-12 cursor-pointer font-semibold text-sm sm:text-base"
+        onClick={handlePayWithRozoWallet}
+        disabled={isRozoWalletPaymentLoading}
+        size="lg"
+      >
+        {isRozoWalletPaymentLoading ? (
+          <>
+            <Loader2 className="mr-2 size-4 animate-spin" />
+            Processing Payment...
+          </>
+        ) : (
+          <>
+            <Wallet className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+            Pay {hasPrice ? `$${service.price_usd}` : "N/A"} with Rozo Wallet
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ai-services/ai-service-discovery-payment.tsx
+++ b/src/components/ai-services/ai-service-discovery-payment.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { PaymentData } from "@/app/receipt/receipt-content";
+import { Button } from "@/components/ui/button";
+import { CustomTooltip } from "@/components/ui/custom-tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useRozoPointAPI } from "@/hooks/useRozoPointAPI";
+import { getAiServiceById } from "@/lib/ai-services";
+import { savePaymentReceipt } from "@/lib/payment-storage";
+import { useAppKitAccount } from "@reown/appkit/react";
+import { baseUSDC, PaymentCompletedEvent } from "@rozoai/intent-common";
+import { RozoPayButton, useRozoPayUI } from "@rozoai/intent-pay";
+import { Coins, CreditCard, HelpCircle, Wallet } from "lucide-react";
+import { useRouter } from "next/navigation";
+import React, { useEffect } from "react";
+import { toast } from "sonner";
+
+const toAddress = "0x5772FBe7a7817ef7F586215CA8b23b8dD22C8897";
+
+interface AiServiceDiscoveryPaymentProps {
+  service: NonNullable<ReturnType<typeof getAiServiceById>>;
+  merchantOrderId: string;
+  userEmail: string;
+  appId: string;
+  validateEmailInput: () => boolean;
+  paymentLoading: boolean;
+  setPaymentLoading: (value: boolean) => void;
+}
+
+export function AiServiceDiscoveryPayment({
+  service,
+  merchantOrderId,
+  userEmail,
+  appId,
+  validateEmailInput,
+  paymentLoading,
+  setPaymentLoading,
+}: AiServiceDiscoveryPaymentProps) {
+  const router = useRouter();
+  const { resetPayment } = useRozoPayUI();
+  const { getPoints, spendPoints } = useRozoPointAPI();
+  const { address, isConnected } = useAppKitAccount();
+
+  const [points, setPoints] = React.useState(0);
+  const [showConfirmDialog, setShowConfirmDialog] = React.useState(false);
+  const [dialogLoading, setDialogLoading] = React.useState(false);
+
+  const priceUsd = service?.price_usd ?? 0;
+  const hasPrice = typeof service?.price_usd === "number";
+  const receiptUrl = `https://ns.rozo.ai/payment/success?order_id=${merchantOrderId}`;
+
+  const metadata = React.useMemo(() => {
+    const baseMetadata = {
+      amount_local: service?.price_usd,
+      currency_local: "USD",
+      email: userEmail,
+      items: [
+        {
+          name: service?.name,
+          description: `${service?.price_usd ?? "N/A"} USD`,
+        },
+      ],
+    };
+
+    if (service?.id) {
+      return {
+        ...baseMetadata,
+        merchant_order_id: merchantOrderId,
+        ...(service?.sold_out ? { receiptUrl: receiptUrl } : {}),
+        items: [
+          ...baseMetadata.items,
+          {
+            name: "Order ID",
+            description: merchantOrderId,
+          },
+        ],
+      };
+    }
+
+    return baseMetadata;
+  }, [
+    service?.price_usd,
+    service?.name,
+    service?.id,
+    service?.sold_out,
+    userEmail,
+    merchantOrderId,
+    receiptUrl,
+  ]);
+
+  // Initial reset payment on mount (discovery-only)
+  useEffect(() => {
+    if (!service) return;
+
+    resetPayment({
+      appId: appId,
+      intent: `Pay for ${service.name}`,
+      toAddress: toAddress,
+      toChain: baseUSDC.chainId,
+      toToken: baseUSDC.token as `0x${string}`,
+      ...(typeof service.price_usd === "number" && {
+        toUnits: service.price_usd.toString(),
+      }),
+      metadata: metadata as any,
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [service?.id]);
+
+  // Update payment metadata when email changes (but only after initial load)
+  useEffect(() => {
+    if (!userEmail || !service) return;
+
+    resetPayment({
+      appId: appId,
+      intent: `Pay for ${service.name}`,
+      toAddress: toAddress,
+      toChain: baseUSDC.chainId,
+      toToken: baseUSDC.token as `0x${string}`,
+      ...(typeof service.price_usd === "number" && {
+        toUnits: service.price_usd.toString(),
+      }),
+      metadata: metadata as any,
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userEmail]);
+
+  // Fetch points balance
+  useEffect(() => {
+    const fetchPoints = async () => {
+      if (!address || !isConnected) return;
+
+      const pts = await getPoints(address);
+      setPoints(pts / 100);
+    };
+    fetchPoints();
+  }, [isConnected, address, getPoints]);
+
+  const handlePaymentCompleted = (_args: PaymentCompletedEvent) => {
+    if (!service) return;
+
+    toast.success(`Payment successful to ${service.name}!`, {
+      description:
+        "Your payment has been processed successfully. Redirecting to receipt...",
+      duration: 2000,
+    });
+
+    // Store payment data in localStorage for receipt page
+    const receiptData: PaymentData = {
+      from_address: address || "",
+      to_handle: service.id,
+      amount_usd_cents: priceUsd * 100,
+      amount_local: priceUsd,
+      currency_local: "USD",
+      timestamp: Date.now(),
+      order_id: merchantOrderId,
+      about: `Pay for ${service.name}`,
+      service_name: service.name,
+      service_domain: service.id,
+      is_using_points: false,
+    };
+
+    console.log("[AI Services] Pay with Crypto - About to save receipt:", {
+      merchantOrderId,
+      receiptData,
+    });
+    savePaymentReceipt(merchantOrderId, receiptData);
+    console.log(
+      "[AI Services] Pay with Crypto - Receipt saved, navigating to /receipt?payment_id=" +
+        merchantOrderId,
+    );
+
+    // Prefetch and navigate to receipt page
+    router.prefetch("/receipt");
+    setTimeout(() => {
+      router.push(`/receipt?payment_id=${merchantOrderId}`);
+    }, 1000);
+  };
+
+  const handlePayWithPoints = () => {
+    if (!validateEmailInput()) {
+      return;
+    }
+    setShowConfirmDialog(true);
+  };
+
+  const confirmPaymentWithPoints = async () => {
+    if (!address || !service) return;
+
+    setDialogLoading(true);
+
+    const paymentData = {
+      from_address: address,
+      to_handle: service.id,
+      amount_usd_cents: priceUsd * 100,
+      amount_local: priceUsd,
+      currency_local: "USD",
+      timestamp: Date.now(),
+      order_id: merchantOrderId,
+      about: `Pay for ${service.name}`,
+    };
+
+    const response = await spendPoints(paymentData);
+
+    if (response && response.status === "success") {
+      // Store payment data in localStorage for receipt page
+      const receiptData = {
+        ...response.data,
+        service_name: service.name,
+        service_domain: service.id,
+        is_using_points: true,
+      };
+
+      console.log("[AI Services] Pay with Points - About to save receipt:", {
+        merchantOrderId,
+        receiptData,
+      });
+      savePaymentReceipt(merchantOrderId, receiptData);
+      console.log(
+        "[AI Services] Pay with Points - Receipt saved, navigating to /receipt?payment_id=" +
+          merchantOrderId,
+      );
+
+      setShowConfirmDialog(false);
+
+      // Navigate to receipt page
+      router.push(`/receipt?payment_id=${merchantOrderId}`);
+    } else {
+      toast.error("Failed to spend points");
+      setDialogLoading(false);
+    }
+  };
+
+  if (!service) return null;
+
+  return (
+    <>
+      {/* Intent SDK for non mini app */}
+      <RozoPayButton.Custom
+        resetOnSuccess
+        appId={appId}
+        intent={`Pay for ${service.name}`}
+        toAddress={toAddress}
+        toChain={baseUSDC.chainId}
+        toToken={baseUSDC.token}
+        {...(service.price_usd && {
+          toUnits: service.price_usd.toString(),
+        })}
+        metadata={metadata as any}
+        onPaymentStarted={() => {
+          setPaymentLoading(true);
+        }}
+        onPaymentCompleted={handlePaymentCompleted}
+      >
+        {({ show }) => (
+          <div className="m-auto flex w-full flex-col gap-2">
+            <Button
+              className="w-full h-11 sm:h-12 text-sm sm:text-base font-semibold"
+              size={"lg"}
+              onClick={() => {
+                if (!validateEmailInput()) {
+                  return;
+                }
+                show();
+              }}
+              disabled={paymentLoading}
+            >
+              {paymentLoading ? (
+                <>
+                  <Wallet className="h-4 w-4 sm:h-5 sm:w-5 animate-pulse" />
+                  Processing Payment...
+                </>
+              ) : (
+                <>
+                  <CreditCard className="h-4 w-4 sm:h-5 sm:w-5" />
+                  Pay with Crypto
+                </>
+              )}
+            </Button>
+          </div>
+        )}
+      </RozoPayButton.Custom>
+
+      {/* Pay with Points Button */}
+      {points > 0 && (
+        <div className="space-y-2">
+          <Button
+            className="w-full h-11 sm:h-12 text-sm sm:text-base font-semibold"
+            size={"lg"}
+            onClick={handlePayWithPoints}
+            variant="outline"
+            disabled={!hasPrice || points < priceUsd}
+          >
+            <Coins className="h-4 w-4 sm:h-5 sm:w-5" />
+            Pay with{" "}
+            {new Intl.NumberFormat("en-US", {
+              style: "decimal",
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0,
+            }).format(priceUsd * 100)}{" "}
+            Points
+          </Button>
+          <div className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1">
+            Available Points: {Number((points ?? 0) * 100).toFixed(2)} pts
+            <CustomTooltip
+              content="Explore all the benefits of Rozo. Rozo points are the rewards for your purchases."
+              position="top"
+              className="w-48 sm:w-[20rem] ml-1.5"
+            >
+              <HelpCircle className="ml-3 size-3 cursor-help text-muted-foreground hover:text-foreground transition-colors" />
+            </CustomTooltip>
+          </div>
+        </div>
+      )}
+
+      {/* Pay with Points Confirmation Dialog */}
+      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Confirm Payment with Points</DialogTitle>
+            <DialogDescription>
+              You are about to pay for{" "}
+              <span className="font-medium text-foreground">
+                {service?.name}
+              </span>{" "}
+              using your Rozo Points.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="bg-muted/50 rounded-lg p-4 space-y-2">
+              <div className="flex justify-between items-center">
+                <span className="text-sm text-muted-foreground">
+                  Points to be used:
+                </span>
+                <span className="font-semibold text-foreground">
+                  {service &&
+                    new Intl.NumberFormat("en-US", {
+                      style: "decimal",
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 0,
+                    }).format(priceUsd * 100)}{" "}
+                  pts
+                </span>
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-sm text-muted-foreground">
+                  Available Points:
+                </span>
+                <span className="font-medium text-muted-foreground">
+                  {Number((points ?? 0) * 100).toFixed(2)} pts
+                </span>
+              </div>
+              <div className="h-px bg-border my-2" />
+              <div className="flex justify-between items-center">
+                <span className="text-sm text-muted-foreground">
+                  Remaining Points:
+                </span>
+                <span className="font-semibold text-foreground">
+                  {service &&
+                    new Intl.NumberFormat("en-US", {
+                      style: "decimal",
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 0,
+                    }).format((points - priceUsd) * 100)}{" "}
+                  pts
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter className="flex-col sm:flex-row gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowConfirmDialog(false)}
+              disabled={dialogLoading}
+              className="w-full sm:w-auto"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={confirmPaymentWithPoints}
+              disabled={dialogLoading}
+              className="w-full sm:w-auto"
+            >
+              {dialogLoading ? (
+                <>
+                  <Wallet className="size-4 animate-pulse mr-2" />
+                  Processing...
+                </>
+              ) : (
+                <>
+                  <Coins className="size-4 mr-2" />
+                  Confirm Payment
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/dapp/dapp-content.tsx
+++ b/src/components/dapp/dapp-content.tsx
@@ -4,12 +4,8 @@ import { PageHeader } from "@/components/page-header";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { getAllAiServices } from "@/lib/ai-services";
-import { getAllRestaurants } from "@/lib/restaurants";
 import { useRozoWallet } from "@/hooks/useRozoWallet";
 import { cn, getFirstTwoWordInitialsFromName } from "@/lib/utils";
-import { VISIBLE_HANDLES } from "@/shared";
-import { useAppKitAccount } from "@reown/appkit/react";
 import { Globe, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -48,26 +44,28 @@ const isFilterRegion = (
   value !== null &&
   FILTER_REGIONS.includes(value as (typeof FILTER_REGIONS)[number]);
 
-interface DappContentProps {
+export interface DappContentProps {
   className?: string;
   title?: string;
   icon?: React.ReactNode;
   isDapp?: boolean;
+  restaurants: DappRestaurant[];
+  aiServices: AiServiceItem[];
+  /** EVM address from AppKit, supplied by discovery-mode wrapper. */
+  evmAddress?: string;
+  evmConnected?: boolean;
 }
-
-const ALL_RESTAURANTS = (getAllRestaurants() as unknown as DappRestaurant[]).filter(
-  (location) => VISIBLE_HANDLES.includes(location.handle),
-);
-const ALL_AI_SERVICES = getAllAiServices() as AiServiceItem[];
 
 export function DappContent({
   className,
   title = "DApps",
   icon = <Globe className="size-6" />,
   isDapp = false,
+  restaurants,
+  aiServices,
+  evmAddress,
+  evmConnected = false,
 }: DappContentProps) {
-  const restaurants = ALL_RESTAURANTS;
-  const aiServices = ALL_AI_SERVICES;
   const [searchValue, setSearchValue] = useState("");
   const router = useRouter();
   const pathname = usePathname();
@@ -78,10 +76,11 @@ export function DappContent({
     : "network-schools";
 
   const { walletAddress, isConnected: isRozoWalletConnected } = useRozoWallet();
-  const { address, isConnected } = useAppKitAccount();
 
   const activeAddress =
-    (isRozoWalletConnected && walletAddress) || (isConnected && address) || "";
+    (isRozoWalletConnected && walletAddress) ||
+    (evmConnected && evmAddress) ||
+    "";
 
   useEffect(() => {
     setSearchValue("");
@@ -201,7 +200,7 @@ export function DappContent({
     return (
       <li key={service.id}>
         <Link
-          href={`/ai-services/${encodeURIComponent(service.id)}`}
+          href={`/ai-services/${encodeURIComponent(service.id)}?dapp=${isDapp}`}
           className={cn(
             "flex items-start gap-3 px-4 py-4",
             "transition-colors duration-200 hover:bg-muted/40",

--- a/src/components/dapp/discovery-dapp-content.tsx
+++ b/src/components/dapp/discovery-dapp-content.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useAppKitAccount } from "@reown/appkit/react";
+import { DappContent, type DappContentProps } from "./dapp-content";
+
+type DiscoveryDappContentProps = Omit<
+  DappContentProps,
+  "evmAddress" | "evmConnected"
+>;
+
+export function DiscoveryDappContent(props: DiscoveryDappContentProps) {
+  const { address, isConnected } = useAppKitAccount();
+
+  return (
+    <DappContent {...props} evmAddress={address} evmConnected={isConnected} />
+  );
+}

--- a/src/components/restaurant/restaurant-dapp-payment.tsx
+++ b/src/components/restaurant/restaurant-dapp-payment.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useRozoWallet } from "@/hooks/useRozoWallet";
+import {
+  formatRozoErrorMessage,
+  isRozoProviderError,
+  isUserCancellation,
+} from "@/lib/rozo-errors";
+import { convertToUSD, getDisplayCurrency } from "@/lib/utils";
+import { savePaymentReceipt } from "@/lib/payment-storage";
+import { Restaurant } from "@/types/restaurant";
+import { PaymentData } from "@/app/receipt/receipt-content";
+import {
+  baseUSDC,
+  createPayment,
+  rozoStellarUSDC,
+} from "@rozoai/intent-common";
+import { Loader2, Wallet } from "lucide-react";
+import { useRouter } from "next/navigation";
+import React from "react";
+import { toast } from "sonner";
+
+interface RestaurantDappPaymentProps {
+  restaurant: Restaurant;
+  paymentAmount: string;
+  appId: string;
+  merchantOrderId: string;
+}
+
+export function RestaurantDappPayment({
+  restaurant,
+  paymentAmount,
+  appId,
+  merchantOrderId,
+}: RestaurantDappPaymentProps) {
+  const router = useRouter();
+  const {
+    isAvailable: isRozoWalletAvailable,
+    isConnected: isRozoWalletConnected,
+    walletAddress: rozoWalletAddress,
+    balance: rozoWalletBalance,
+    balanceUsd: rozoWalletBalanceUsd,
+    isLoading: rozoWalletLoading,
+    transferUSDC: rozoWalletTransfer,
+  } = useRozoWallet();
+
+  const [isRozoWalletPaymentLoading, setIsRozoWalletPaymentLoading] =
+    React.useState(false);
+
+  const toAddress = React.useMemo(() => {
+    return restaurant?.payTo ?? "0x5772FBe7a7817ef7F586215CA8b23b8dD22C8897";
+  }, [restaurant]);
+
+  const receiptUrl = `https://ns.rozo.ai/payment/success?order_id=${merchantOrderId}`;
+
+  const generateMetadata = (amountLocal: string, currencyLocal: string) => {
+    const displayCurrency = getDisplayCurrency(currencyLocal);
+    const usdAmount = convertToUSD(amountLocal, displayCurrency);
+
+    const baseMetadata = {
+      amount_local: amountLocal,
+      currency_local: displayCurrency,
+      items: [
+        {
+          name: restaurant?.name,
+          description: `${displayCurrency} ${amountLocal} (${usdAmount} USD)`,
+        },
+      ],
+    };
+
+    if (restaurant?.handle && restaurant?.name) {
+      return {
+        ...baseMetadata,
+        merchant_order_id: merchantOrderId,
+        ...(restaurant?.is_live ? { receiptUrl: receiptUrl } : {}),
+        items: [
+          ...baseMetadata.items,
+          {
+            name: "Order ID",
+            description: merchantOrderId,
+          },
+        ],
+      };
+    }
+
+    return baseMetadata;
+  };
+
+  // Pay with Rozo Wallet (Stellar USDC)
+  // Only shown when page is opened in Rozo Wallet mobile app
+  // Uses window.rozo provider for gasless USDC transfers
+  const generateBridgeAddress = async (params: {
+    amountUsd: string;
+    amountLocal: string;
+    currencyLocal: string;
+  }): Promise<{
+    amount: string;
+    bridgeAddress: string;
+    memo: string;
+    receiverAddressContract?: string;
+    receiverMemoContract?: string;
+  }> => {
+    const displayCurrency = getDisplayCurrency(params.currencyLocal);
+
+    const payment = await createPayment({
+      appId: appId,
+      toAddress: toAddress,
+      toChain: baseUSDC.chainId,
+      toToken: baseUSDC.token,
+      toUnits: params.amountUsd,
+      preferredChain: rozoStellarUSDC.chainId,
+      preferredTokenAddress: rozoStellarUSDC.token,
+      metadata: generateMetadata(params.amountLocal, displayCurrency) as any,
+      title: `Pay for ${restaurant?.name} - ${displayCurrency} ${params.amountLocal} ($${params.amountUsd})`,
+    });
+
+    if (
+      !payment.source.receiverAddress ||
+      !payment.source.amount ||
+      !payment.source.receiverMemo
+    ) {
+      throw new Error("Failed to generate bridge address");
+    }
+
+    return {
+      amount: payment.source.amount,
+      bridgeAddress: payment.source.receiverAddress,
+      memo: payment.source.receiverMemo,
+      receiverAddressContract: payment.source.receiverAddressContract,
+      receiverMemoContract: payment.source.receiverMemoContract,
+    };
+  };
+
+  const handlePayWithRozoWallet = async () => {
+    if (!restaurant || !paymentAmount) return;
+
+    try {
+      setIsRozoWalletPaymentLoading(true);
+
+      const displayCurrency = getDisplayCurrency(restaurant.currency);
+      const usdAmount = convertToUSD(paymentAmount, displayCurrency);
+
+      // Transfer USDC on Stellar network
+      const { amount, receiverAddressContract, receiverMemoContract } =
+        await generateBridgeAddress({
+          amountUsd: usdAmount,
+          amountLocal: paymentAmount,
+          currencyLocal: displayCurrency,
+        });
+
+      const result = await rozoWalletTransfer(
+        amount,
+        receiverAddressContract,
+        receiverMemoContract,
+      );
+
+      if (result.hash) {
+        // Store receipt data
+        const receiptData: PaymentData = {
+          from_address: rozoWalletAddress || "",
+          to_handle:
+            restaurant.handle ||
+            restaurant.name.toLowerCase().replace(/\s+/g, ""),
+          amount_usd_cents: parseFloat(usdAmount) * 100,
+          amount_local: parseFloat(paymentAmount),
+          currency_local: displayCurrency,
+          timestamp: Date.now(),
+          order_id: merchantOrderId,
+          about: `Pay for ${restaurant.name} - ${displayCurrency} ${paymentAmount}`,
+          restaurant_name: restaurant.name,
+          restaurant_address: restaurant.address_line1,
+          is_using_points: false,
+        };
+
+        console.log(
+          "[Restaurant] Pay with Rozo Wallet - About to save receipt:",
+          {
+            merchantOrderId,
+            receiptData,
+          },
+        );
+        savePaymentReceipt(merchantOrderId, receiptData);
+        console.log(
+          "[Restaurant] Pay with Rozo Wallet - Receipt saved, navigating to /receipt?payment_id=" +
+            merchantOrderId +
+            "&withRozoWallet=true",
+        );
+
+        toast.success(`Payment successful to ${restaurant.name}!`);
+        router.push(
+          `/receipt?payment_id=${merchantOrderId}&withRozoWallet=true`,
+        );
+      }
+    } catch (error: unknown) {
+      console.error("Rozo Wallet payment error:", error);
+
+      if (isUserCancellation(error)) {
+        toast.error("Payment cancelled");
+        return;
+      }
+
+      if (isRozoProviderError(error)) {
+        toast.error(formatRozoErrorMessage(error));
+        return;
+      }
+
+      const fallback =
+        error instanceof Error
+          ? error.message
+          : "Payment failed. Please try again.";
+      toast.error(fallback);
+    } finally {
+      setIsRozoWalletPaymentLoading(false);
+    }
+  };
+
+  if (!isRozoWalletAvailable || !isRozoWalletConnected) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* Balance Display */}
+      {rozoWalletBalance && (
+        <p className="text-xs text-muted-foreground text-center">
+          Rozo Wallet Balance: {rozoWalletBalance}
+        </p>
+      )}
+
+      {/* Pay with Rozo Wallet Button */}
+      <Button
+        variant="default"
+        className="w-full h-11 sm:h-12 cursor-pointer font-semibold text-sm sm:text-base"
+        onClick={handlePayWithRozoWallet}
+        disabled={
+          isRozoWalletPaymentLoading ||
+          !paymentAmount ||
+          parseFloat(paymentAmount) <= 0 ||
+          isNaN(parseFloat(paymentAmount)) ||
+          rozoWalletLoading ||
+          (rozoWalletBalanceUsd !== null && rozoWalletBalanceUsd <= 0)
+        }
+        size="lg"
+      >
+        {isRozoWalletPaymentLoading ? (
+          <Loader2 className="mr-2 size-4 animate-spin" />
+        ) : (
+          <Wallet className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+        )}
+        {rozoWalletBalanceUsd !== null && rozoWalletBalanceUsd > 0 ? (
+          <>
+            Pay $
+            {isNaN(
+              parseFloat(
+                convertToUSD(
+                  paymentAmount || "0",
+                  getDisplayCurrency(restaurant?.currency),
+                ),
+              ),
+            )
+              ? "0.00"
+              : convertToUSD(
+                  paymentAmount || "0",
+                  getDisplayCurrency(restaurant?.currency),
+                )}{" "}
+            with Rozo Wallet
+          </>
+        ) : (
+          "Insufficient Rozo Wallet Balance"
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/restaurant/restaurant-discovery-payment.tsx
+++ b/src/components/restaurant/restaurant-discovery-payment.tsx
@@ -1,0 +1,506 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { CustomTooltip } from "@/components/ui/custom-tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useRozoPointAPI } from "@/hooks/useRozoPointAPI";
+import { convertToUSD, getDisplayCurrency } from "@/lib/utils";
+import { savePaymentReceipt } from "@/lib/payment-storage";
+import { Restaurant } from "@/types/restaurant";
+import { PaymentData } from "@/app/receipt/receipt-content";
+import { useAppKitAccount } from "@reown/appkit/react";
+import {
+  baseUSDC,
+  PaymentCompletedEvent,
+} from "@rozoai/intent-common";
+import { RozoPayButton, useRozoPay, useRozoPayUI } from "@rozoai/intent-pay";
+import { Coins, CreditCard, HelpCircle, Loader2, Wallet } from "lucide-react";
+import { useRouter } from "next/navigation";
+import React, { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+interface RestaurantDiscoveryPaymentProps {
+  restaurant: Restaurant;
+  paymentAmount: string;
+  appId: string;
+  merchantOrderId: string;
+  toAddress: string;
+  generateMetadata: (amountLocal: string, currencyLocal: string) => object;
+  loading: boolean;
+  setLoading: (value: boolean) => void;
+}
+
+export function RestaurantDiscoveryPayment({
+  restaurant,
+  paymentAmount,
+  appId,
+  merchantOrderId,
+  toAddress,
+  generateMetadata,
+  loading,
+  setLoading,
+}: RestaurantDiscoveryPaymentProps) {
+  const router = useRouter();
+  const { resetPayment } = useRozoPayUI();
+  const { paymentState } = useRozoPay();
+  const { getPoints, spendPoints } = useRozoPointAPI();
+  const { address, isConnected } = useAppKitAccount();
+
+  const [points, setPoints] = React.useState(0);
+  const [pointsLoading, setPointsLoading] = React.useState(false);
+  const [showConfirmDialog, setShowConfirmDialog] = React.useState(false);
+  const [dialogLoading, setDialogLoading] = React.useState(false);
+  const [isDebouncing, setIsDebouncing] = React.useState(false);
+
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const isFirstAmountEffectRef = useRef(true);
+
+  // Initial reset payment on mount (discovery-only)
+  useEffect(() => {
+    if (!restaurant) return;
+
+    const price =
+      restaurant.price && !isNaN(Number(restaurant.price))
+        ? Number(restaurant.price)
+        : 0;
+    const displayCurrency = restaurant.currency || "USD";
+    const usdAmount = convertToUSD(price.toFixed(2), displayCurrency);
+
+    resetPayment({
+      appId: appId,
+      intent: `${restaurant.name} - ${displayCurrency} ${price.toFixed(2)}`,
+      toAddress: restaurant.payTo ?? "0x5772FBe7a7817ef7F586215CA8b23b8dD22C8897",
+      toChain: baseUSDC.chainId,
+      toToken: baseUSDC.token as `0x${string}`,
+      toUnits: usdAmount,
+      metadata: generateMetadata(price.toFixed(2), displayCurrency) as any,
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [restaurant?._id]);
+
+  // Fetch points balance
+  useEffect(() => {
+    const fetchPoints = async () => {
+      if (!address) return;
+
+      setPointsLoading(true);
+      const pts = await getPoints(address);
+      setPoints(pts / 100);
+      setPointsLoading(false);
+    };
+    fetchPoints();
+  }, [isConnected, address, getPoints]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  // Debounced resetPayment when payment amount changes (skip initial mount,
+  // which is already handled by the mount effect above)
+  useEffect(() => {
+    if (!restaurant) return;
+
+    if (isFirstAmountEffectRef.current) {
+      isFirstAmountEffectRef.current = false;
+      return;
+    }
+
+    setIsDebouncing(true);
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    debounceTimerRef.current = setTimeout(async () => {
+      const displayCurrency = getDisplayCurrency(restaurant.currency);
+      const usdAmount = convertToUSD(paymentAmount, displayCurrency);
+
+      await resetPayment({
+        appId: appId,
+        intent: `Pay for ${restaurant.name} - ${displayCurrency}${paymentAmount} ($${usdAmount})`,
+        toAddress: "0x5772FBe7a7817ef7F586215CA8b23b8dD22C8897",
+        toChain: baseUSDC.chainId,
+        toToken: baseUSDC.token as `0x${string}`,
+        toUnits: usdAmount, // Use USD amount for payment processing
+        metadata: generateMetadata(paymentAmount, displayCurrency) as any,
+      });
+
+      setIsDebouncing(false);
+      debounceTimerRef.current = null;
+    }, 500);
+
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paymentAmount]);
+
+  const handlePaymentCompleted = (args?: PaymentCompletedEvent) => {
+    console.log("[Restaurant] Payment completed:", args);
+
+    if (!restaurant) return;
+
+    toast.success(`Payment successful to ${restaurant.name}!`, {
+      description:
+        "Your payment has been processed successfully. Redirecting to receipt...",
+      duration: 2000,
+    });
+
+    // Store payment data in sessionStorage for receipt page
+    const displayCurrency = getDisplayCurrency(restaurant?.currency);
+    const usdAmount = convertToUSD(paymentAmount, displayCurrency);
+
+    const receiptData: PaymentData = {
+      from_address: address || "",
+      to_handle:
+        restaurant.handle || restaurant.name.toLowerCase().replace(/\s+/g, ""),
+      amount_usd_cents: parseFloat(usdAmount) * 100,
+      amount_local: parseFloat(paymentAmount),
+      currency_local: displayCurrency,
+      timestamp: Date.now(),
+      order_id: merchantOrderId,
+      about: `Pay for ${restaurant.name} - ${displayCurrency} ${paymentAmount}`,
+      restaurant_name: restaurant.name,
+      restaurant_address: restaurant.address_line1,
+      is_using_points: false,
+    };
+
+    console.log("[Restaurant] Pay with Crypto - About to save receipt:", {
+      merchantOrderId,
+      receiptData,
+    });
+    savePaymentReceipt(merchantOrderId, receiptData);
+    console.log(
+      "[Restaurant] Pay with Crypto - Receipt saved, navigating to /receipt?payment_id=" +
+        merchantOrderId,
+    );
+
+    setTimeout(() => {
+      setLoading(false);
+      router.push(`/receipt?payment_id=${merchantOrderId}`);
+    }, 1000);
+  };
+
+  const handlePayWithPoints = () => {
+    setShowConfirmDialog(true);
+  };
+
+  const confirmPaymentWithPoints = async () => {
+    try {
+      if (!address || !restaurant || !paymentAmount) return;
+
+      setDialogLoading(true);
+
+      const displayCurrency = getDisplayCurrency(restaurant?.currency);
+      const usdAmount = convertToUSD(paymentAmount, displayCurrency);
+
+      const paymentData = {
+        from_address: address,
+        to_handle:
+          restaurant.handle ||
+          restaurant.name.toLowerCase().replace(/\s+/g, ""),
+        amount_usd_cents: parseFloat(usdAmount) * 100,
+        amount_local: parseFloat(paymentAmount),
+        currency_local: displayCurrency,
+        timestamp: Date.now(),
+        order_id: merchantOrderId,
+        about: `Pay for ${restaurant.name} - $${paymentAmount}`,
+      };
+      const response = await spendPoints(paymentData);
+
+      if (response && response.status === "success") {
+        // Store payment data in localStorage for receipt page
+        const receiptData: PaymentData = {
+          ...response.data,
+          restaurant_name: restaurant.name,
+          restaurant_address: restaurant.address_line1,
+          is_using_points: true,
+        };
+
+        console.log("[Restaurant] Pay with Points - About to save receipt:", {
+          merchantOrderId,
+          receiptData,
+        });
+        savePaymentReceipt(merchantOrderId, receiptData);
+        console.log(
+          "[Restaurant] Pay with Points - Receipt saved, navigating to /receipt?payment_id=" +
+            merchantOrderId,
+        );
+
+        setShowConfirmDialog(false);
+        toast.success("Points spent successfully");
+        // Navigate to receipt page
+        router.push(`/receipt?payment_id=${merchantOrderId}`);
+      } else {
+        toast.error("Failed to spend points");
+        setDialogLoading(false);
+      }
+    } catch {
+      toast.error("Failed to spend points");
+      setDialogLoading(false);
+    }
+  };
+
+  if (!restaurant) return null;
+
+  return (
+    <>
+      {/* Payment Button */}
+      <RozoPayButton.Custom
+        resetOnSuccess
+        appId={appId}
+        toAddress={toAddress}
+        toChain={baseUSDC.chainId}
+        {...(paymentAmount && parseFloat(paymentAmount) > 0
+          ? {
+              toUnits: convertToUSD(
+                paymentAmount,
+                getDisplayCurrency(restaurant?.currency),
+              ),
+            }
+          : {})}
+        toToken={baseUSDC.token}
+        intent={`Pay for ${restaurant.name} - ${getDisplayCurrency(
+          restaurant?.currency,
+        )} ${paymentAmount}`}
+        onPaymentStarted={() => {
+          setLoading(true);
+        }}
+        onPaymentCompleted={(args: PaymentCompletedEvent) => {
+          handlePaymentCompleted(args);
+        }}
+      >
+        {({ show }) => {
+          const usdAmount = convertToUSD(
+            paymentAmount,
+            getDisplayCurrency(restaurant?.currency),
+          );
+
+          return (
+            <Button
+              variant="default"
+              className="w-full h-11 sm:h-12 cursor-pointer font-semibold text-sm sm:text-base"
+              onClick={show}
+              disabled={
+                isDebouncing ||
+                loading ||
+                !paymentAmount ||
+                parseFloat(paymentAmount) <= 0 ||
+                isNaN(parseFloat(paymentAmount)) ||
+                paymentState !== "preview"
+              }
+              size="lg"
+            >
+              {loading ? (
+                <Loader2 className="mr-2 size-4 animate-spin" />
+              ) : (
+                <CreditCard className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+              )}
+              Pay ${isNaN(parseFloat(usdAmount)) ? "0.00" : usdAmount} with
+              Crypto
+            </Button>
+          );
+        }}
+      </RozoPayButton.Custom>
+
+      {/* Pay with Points Button */}
+      {points > 0 && (
+        <div className="space-y-2">
+          <Button
+            className="w-full h-11 sm:h-12 text-sm sm:text-base font-semibold"
+            size="lg"
+            onClick={handlePayWithPoints}
+            variant="outline"
+            disabled={
+              !paymentAmount ||
+              parseFloat(paymentAmount) <= 0 ||
+              isNaN(parseFloat(paymentAmount)) ||
+              points <
+                parseFloat(
+                  convertToUSD(
+                    paymentAmount,
+                    getDisplayCurrency(restaurant?.currency),
+                  ),
+                )
+            }
+          >
+            <Coins className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+            Pay with{" "}
+            {new Intl.NumberFormat("en-US", {
+              style: "decimal",
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0,
+            }).format(
+              isNaN(
+                parseFloat(
+                  convertToUSD(
+                    paymentAmount || "0",
+                    getDisplayCurrency(restaurant?.currency),
+                  ),
+                ),
+              )
+                ? 0
+                : parseFloat(
+                    convertToUSD(
+                      paymentAmount || "0",
+                      getDisplayCurrency(restaurant?.currency),
+                    ),
+                  ) * 100,
+            )}{" "}
+            Points
+          </Button>
+          <div className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1">
+            Available Points: {Number((points ?? 0) * 100).toFixed(2)} pts
+            <CustomTooltip
+              content="Explore all the benefits of Rozo. Rozo points are the rewards for your purchases."
+              position="top"
+              className="w-48 sm:w-[20rem] ml-1.5"
+            >
+              <HelpCircle className="ml-3 size-3 cursor-help text-muted-foreground hover:text-foreground transition-colors" />
+            </CustomTooltip>
+          </div>
+        </div>
+      )}
+
+      {/* Pay with Points Confirmation Dialog */}
+      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Confirm Payment with Points</DialogTitle>
+            <DialogDescription>
+              You are about to pay for{" "}
+              <span className="font-medium text-foreground">
+                {restaurant?.name}
+              </span>{" "}
+              using your Rozo Points.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="bg-muted/50 rounded-lg p-4 space-y-2">
+              {getDisplayCurrency(restaurant?.currency) !== "USD" && (
+                <>
+                  <div className="flex justify-between items-center">
+                    <span className="text-sm text-muted-foreground">
+                      Amount ({getDisplayCurrency(restaurant?.currency)}):
+                    </span>
+                    <span className="font-medium text-foreground">
+                      {getDisplayCurrency(restaurant?.currency)} {paymentAmount}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center">
+                    <span className="text-sm text-muted-foreground">
+                      USD Equivalent:
+                    </span>
+                    <span className="font-medium text-foreground">
+                      ${" "}
+                      {convertToUSD(
+                        paymentAmount,
+                        getDisplayCurrency(restaurant?.currency),
+                      )}
+                    </span>
+                  </div>
+                </>
+              )}
+              <div className="flex justify-between items-center">
+                <span className="text-sm text-muted-foreground">
+                  Points to be used:
+                </span>
+                <span className="font-semibold text-foreground">
+                  {paymentAmount &&
+                    new Intl.NumberFormat("en-US", {
+                      style: "decimal",
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 0,
+                    }).format(
+                      parseFloat(
+                        convertToUSD(
+                          paymentAmount,
+                          getDisplayCurrency(restaurant?.currency),
+                        ),
+                      ) * 100,
+                    )}{" "}
+                  pts
+                </span>
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-sm text-muted-foreground">
+                  Available Points:
+                </span>
+                <span className="font-medium text-muted-foreground">
+                  {Number((points ?? 0) * 100).toFixed(2)} pts{" "}
+                </span>
+              </div>
+              <div className="h-px bg-border my-2" />
+              <div className="flex justify-between items-center">
+                <span className="text-sm text-muted-foreground">
+                  Remaining Points:
+                </span>
+                <span className="font-semibold text-foreground">
+                  {paymentAmount &&
+                    new Intl.NumberFormat("en-US", {
+                      style: "decimal",
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 0,
+                    }).format(
+                      (points -
+                        parseFloat(
+                          convertToUSD(
+                            paymentAmount,
+                            getDisplayCurrency(restaurant?.currency),
+                          ),
+                        )) *
+                        100,
+                    )}{" "}
+                  pts
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter className="flex-col sm:flex-row gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowConfirmDialog(false)}
+              disabled={dialogLoading}
+              className="w-full sm:w-auto"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={confirmPaymentWithPoints}
+              disabled={dialogLoading}
+              className="w-full sm:w-auto"
+            >
+              {dialogLoading ? (
+                <>
+                  <Wallet className="size-4 animate-pulse mr-2" />
+                  Processing...
+                </>
+              ) : (
+                <>
+                  <Coins className="size-4 mr-2" />
+                  Confirm Payment
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/providers/Web3Provider.tsx
+++ b/src/providers/Web3Provider.tsx
@@ -3,7 +3,7 @@
 import { initializeAppKit, wagmiAdapter } from "@/lib/appkit";
 import { AppKitProvider } from "@reown/appkit/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { base } from "viem/chains";
 import { Config, cookieToInitialState, WagmiProvider } from "wagmi";
 
@@ -21,20 +21,11 @@ export default function Web3Provider({
     cookies
   );
 
-  const [appKitInstance, setAppKitInstance] = useState<any>(null);
-
-  // Initialize AppKit only once when the component mounts
-  useEffect(() => {
-    const instance = initializeAppKit();
-    if (instance) {
-      setAppKitInstance(instance);
-    }
-  }, []);
-
-  // Don't render children until AppKit is initialized
-  if (!appKitInstance || !appKitInstance) {
-    return null;
-  }
+  // Initialize synchronously on the client so the first client render
+  // already has the AppKit instance (avoids a render gate via useEffect).
+  const [appKitInstance] = useState(() =>
+    typeof window !== "undefined" ? initializeAppKit() : null,
+  );
 
   return (
     <WagmiProvider
@@ -42,9 +33,13 @@ export default function Web3Provider({
       initialState={initialState}
     >
       <QueryClientProvider client={queryClient}>
-        <AppKitProvider {...appKitInstance} defaultNetwork={base}>
-          {children}
-        </AppKitProvider>
+        {appKitInstance ? (
+          <AppKitProvider {...appKitInstance} defaultNetwork={base}>
+            {children}
+          </AppKitProvider>
+        ) : (
+          children
+        )}
       </QueryClientProvider>
     </WagmiProvider>
   );


### PR DESCRIPTION
## Summary

/dapp, /ai-services, /discovery, restaurant detail, and AI-service detail pages mixed mini-app (“dapp”) and browser (“discovery”) concerns in giant client components. Split into mode-specific payment components, moved data fetching to server components, made Web3Provider init AppKit synchronously.


## Changes Made
	•	dapp/ai-services/discovery pages → server components, fetch restaurants/AI services, pass as props.
	•	DappContent now takes restaurants/aiServices/evmAddress/evmConnected as props (no module-level consts, no direct useAppKitAccount).
	•	New DiscoveryDappContent wrapper supplies AppKit address/connection for browser variant.
	•	Restaurant detail page: extracted RestaurantDappPayment / RestaurantDiscoveryPayment (lazy via next/dynamic, ssr: false), removed ~680 lines inline payment logic.
	•	AI-service detail page: extracted AiServiceDappPayment / AiServiceDiscoveryPayment (lazy), removed ~545 lines; added ?dapp= propagation to links.
	•	Web3Provider: replaced useEffect init + return null gate with useState(() => initializeAppKit()), renders children immediately.
	•	.claude/settings.local.json: added dev command allowlist entries (tsc, lint, build, rtk).


## How to Test
	1.	bun dev. /dapp → Rozo Wallet payment flow.
	2.	/discovery, /ai-services → AppKit wallet flow (crypto/points).
	3.	Restaurant detail in both modes (?dapp=true vs not) → correct payment component, amounts/cashback correct.
	4.	AI-service detail both modes → correct payment component, email validation, Intercom flow.
	5.	No duplicate AppKit modal, no flash-of-null on load.
Testing Checklist
	•	Unit tests added/updated
	•	Integration tests added/updated
	•	Edge cases covered
	•	Manual testing completed
	•	No regressions in existing tests


## Reviewer Notes
	•	Mostly relocation — verify dapp vs discovery payment behavior matches old combined component.
	•	Web3Provider sync init: check no SSR/hydration mismatch.
	•	Run bun test:e2e:payments against both dapp and discovery routes — one path could break silently while other passes