### PR TITLE
Fix - Correct amount input concat bug and rozo wallet balance loading

### DIFF
--- a/src/app/restaurant/[id]/page.tsx
+++ b/src/app/restaurant/[id]/page.tsx
@@ -98,7 +98,7 @@ export default function RestaurantDetailPage() {
   const [paymentLoading, setPaymentLoading] = React.useState(false);
   const [paymentAmount, setPaymentAmount] = React.useState<string>(() => {
     const price = restaurant?.price && !isNaN(Number(restaurant.price)) ? Number(restaurant.price) : 0;
-    return price.toFixed(2);
+    return price > 0 ? price.toFixed(2) : "";
   });
   const [points, setPoints] = React.useState(0);
   const [pointsLoading, setPointsLoading] = React.useState(false);
@@ -771,8 +771,10 @@ export default function RestaurantDetailPage() {
                       ) : (
                         <Wallet className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
                       )}
-                      {rozoWalletBalanceUsd !== null &&
-                      rozoWalletBalanceUsd > 0 ? (
+                      {rozoWalletLoading ? (
+                        "Loading Rozo Wallet Balance..."
+                      ) : rozoWalletBalanceUsd !== null &&
+                        rozoWalletBalanceUsd > 0 ? (
                         <>
                           Pay $
                           {isNaN(

--- a/src/components/restaurant/restaurant-dapp-payment.tsx
+++ b/src/components/restaurant/restaurant-dapp-payment.tsx
@@ -1,16 +1,16 @@
 "use client";
 
+import { PaymentData } from "@/app/receipt/receipt-content";
 import { Button } from "@/components/ui/button";
 import { useRozoWallet } from "@/hooks/useRozoWallet";
+import { savePaymentReceipt } from "@/lib/payment-storage";
 import {
   formatRozoErrorMessage,
   isRozoProviderError,
   isUserCancellation,
 } from "@/lib/rozo-errors";
 import { convertToUSD, getDisplayCurrency } from "@/lib/utils";
-import { savePaymentReceipt } from "@/lib/payment-storage";
 import { Restaurant } from "@/types/restaurant";
-import { PaymentData } from "@/app/receipt/receipt-content";
 import {
   baseUSDC,
   createPayment,
@@ -248,7 +248,9 @@ export function RestaurantDappPayment({
         ) : (
           <Wallet className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
         )}
-        {rozoWalletBalanceUsd !== null && rozoWalletBalanceUsd > 0 ? (
+        {rozoWalletLoading ? (
+          "Loading Rozo Wallet Balance..."
+        ) : rozoWalletBalanceUsd !== null && rozoWalletBalanceUsd > 0 ? (
           <>
             Pay $
             {isNaN(

--- a/src/hooks/useRozoWallet.ts
+++ b/src/hooks/useRozoWallet.ts
@@ -97,6 +97,7 @@ export function useRozoWallet() {
       }
 
       setIsAvailable(true);
+      setIsLoading(true);
 
       try {
         // Check connection
@@ -122,6 +123,8 @@ export function useRozoWallet() {
       } catch (error) {
         console.error("Failed to check Rozo Wallet:", error);
         setIsAvailable(false);
+      } finally {
+        setIsLoading(false);
       }
     }
 


### PR DESCRIPTION
## Summary

Restaurant detail page payment amount input started prefilled "0.00", so typing "1" concatenated to "0.001". Rozo Wallet balance also showed "Insufficient Balance" during initial load since isLoading wasn't set during the async check.

## Changes Made

  - `src/app/restaurant/[id]/page.tsx`: init paymentAmount to "" instead of "0.00" when price is 0 (placeholder still shows 0.00)
  - `src/hooks/useRozoWallet.ts`: set isLoading true/false around initial checkRozoWallet fetch
  - Restaurant Rozo Wallet pay button: show `"Loading Rozo Wallet Balance..."` while rozoWalletLoading, before falling to `"Insufficient Rozo Wallet Balance"`

## How to Test

  1. Open restaurant detail page (live restaurant) with no preset price
  2. Click amount field, type 1 → expect 1, not 0.001
  3. Open in Rozo Wallet webview, observe pay button briefly shows "Loading Rozo Wallet Balance..." then correct balance-based label