### PR TITLE
feat(dapp-payin): instant fast-path for Stellar contract payments

### DIFF
--- a/docs/20260616-dapp-payin-callback-design.md
+++ b/docs/20260616-dapp-payin-callback-design.md
@@ -1,0 +1,229 @@
+# dApp /payin 回调 —— 让 Stellar 合约支付秒级确认(设计文档)
+
+**日期**: 2026-06-16
+**仓库**: rozo-rewards-miniapp(前端 dApp)
+**分支**: `feat/dapp-payin-callback`
+**状态**: 设计完成,待 codex review → 待实施
+**关联后端**: rozo-intents-api 已上线合约 `/payin` 即时快路径(commit `133b51b`);
+本文是让该快路径**真正被触发**的前端一环。
+
+---
+
+## 0. 一句话目标
+
+用户在 dApp 里用 Rozo Wallet 付一笔 Stellar 合约支付(`pay()`),拿到 txHash 后,
+**前端立刻 `POST /payments/{id}/payin` 把 txHash 告诉后端** → 后端当场解析链上
+`payment_event` 并秒级结算,不再等每分钟 cron(实测从 ~32s → 秒级)。
+
+---
+
+## 1. 背景:为什么现在慢
+
+- 合约支付(`pay()` via Soroban)目前**只靠后端 `monitor-stellar` 每分钟 cron 轮询**
+  `getEvents` 发现 → 检测耗时 17–42s,最坏 ~60s(抖动,不是固定慢)。
+- 后端**已经上线了即时快路径**:只要有人 `POST /payments/{id}/payin` 带 txHash,
+  后端就用 Soroban RPC 点查这笔 tx 的 `payment_event`、验证、秒级结算。
+- **但当前没有任何客户端调 `/payin`**(后端实测 `immediate_verification` 全 0)→
+  快路径能力闲置,所有合约单仍走 cron 慢路径。
+- **本仓 dApp 就是真正的支付发起方**,在这里加回调是让快路径生效的最小改动。
+
+> 实证(2026-06-16):真实 ZEN 单 `1d982dc5` 第一次走 cron = 32.3s;同一笔 txHash
+> 手动调 /payin → 8.8s 且走快路径(`immediate_verification=true`)。
+
+---
+
+## 2. 现状代码(已查证,带行号)
+
+### 2.1 钱包桥:`window.rozo`
+`src/types/window.d.ts` —— native wallet 注入的 provider:
+```ts
+window.rozo.signAuthEntry(authEntryXdr, { func, submit, message })
+  : Promise<{ signedAuthEntry: string; hash: string; status: string; error?: string }>
+//                                       ^^^^ ← Stellar txHash 在这里
+```
+
+### 2.2 支付链路
+| 步骤 | 位置 | 关键 |
+|---|---|---|
+| 创建 intent | `restaurant-dapp-payment.tsx:108` `createPayment(...)` | 返回 `PaymentResponse`,**含 `id: string`(rozo paymentId UUID)** + `source.{receiverAddress, receiverMemo, amount, receiverAddressContract, receiverMemoContract}` |
+| 构建 + 提交 pay() | `useRozoWallet.ts:167-281` `transferUSDC()` | `window.rozo.signAuthEntry(..., {submit:true})` → 返回 `{ hash }` |
+| 拿到 txHash | `restaurant-dapp-payment.tsx` `handlePayWithRozoWallet` 的 `if (result.hash) {...}` | **回调插入点** |
+| AI 服务同款 | `ai-service-dapp-payment.tsx`(~157-201) | 同样的 `if (result.hash)` 块 |
+
+### 2.3 🔴 关键缺口(本设计的核心改动点)
+`generateBridgeAddress()`(`restaurant-dapp-payment.tsx:100-137`)拿到 `payment` 后
+**只 return 了 5 个字段,把 `payment.id` 丢弃了**:
+```ts
+const payment = await createPayment({...});   // payment.id 是 rozo paymentId
+return {
+  amount: payment.source.amount,
+  bridgeAddress: payment.source.receiverAddress,
+  memo: payment.source.receiverMemo,
+  receiverAddressContract: payment.source.receiverAddressContract,
+  receiverMemoContract: payment.source.receiverMemoContract,
+  // ❌ payment.id 没透传出来
+};
+```
+=> 要调 `/payments/{id}/payin`,**必须先把 `payment.id` 从 `generateBridgeAddress`
+透传到 `handlePayWithRozoWallet`**。这是改动的第一块。
+
+### 2.4 后端接口(rozo-intents-api,已上线)
+| | |
+|---|---|
+| Method/Path | `POST /payments/{paymentId}/payin` |
+| Base URL | `https://aozudqtlykbhzbuzalzz.supabase.co/functions/v1/payment-api` |
+| Auth | **无需任何 header**(函数 `--no-verify-jwt`) |
+| Body | `{ "txHash": "<stellar_tx_hash>", "fromAddress": "<可选>" }` |
+| 合约单成功响应 | `{ "message": "Payin registered (contract fast-path)", ... }` |
+
+---
+
+## 3. 设计
+
+### 3.1 数据流(改后)
+```
+handlePayWithRozoWallet
+  ├─ generateBridgeAddress()  → 现在额外返回 paymentId (= payment.id)
+  ├─ transferUSDC()           → result.hash (txHash)
+  └─ if (result.hash):
+       ├─ notifyPayin(paymentId, result.hash)   ← 新增:POST /payin(fire-and-forget,不阻塞 UI)
+       ├─ savePaymentReceipt(...)               ← 原有
+       ├─ capture(PAYMENT_COMPLETED)            ← 原有
+       └─ router.push(/receipt...)              ← 原有
+```
+
+### 3.2 新增一个薄 helper:`src/lib/notify-payin.ts`
+```ts
+// 把 txHash 报给后端,触发合约即时快路径。fire-and-forget:绝不阻塞/打断支付 UI。
+const PAYMENT_API_BASE =
+  process.env.NEXT_PUBLIC_ROZO_PAYMENT_API ??
+  "https://aozudqtlykbhzbuzalzz.supabase.co/functions/v1/payment-api";
+
+export async function notifyPayin(
+  paymentId: string,
+  txHash: string,
+  fromAddress?: string,
+): Promise<void> {
+  if (!paymentId || !txHash) return;
+  try {
+    await fetch(`${PAYMENT_API_BASE}/payments/${paymentId}/payin`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ txHash, fromAddress }),
+      keepalive: true, // 让请求在页面跳转(router.push)后仍能完成
+    });
+  } catch {
+    // 后端 cron 是兜底,这里失败不影响支付成功;静默吞掉(不打断用户)
+  }
+}
+```
+
+### 3.3 调用时机(关键 —— 决定能不能命中快路径)
+
+#### 🔴 前端能区分"签完名/已提交" vs "已上链确认"吗?——目前**不能**(实测)
+- `transferUSDC` 返回 `TransferResult { hash, status, signedAuthEntry }`(`useRozoWallet.ts:54`)。
+- `result.status` 是 native wallet relayer 返回的**裸字符串**(`window.d.ts:48` `status: string`,
+  无枚举约束)。`submit:true` 是 **relayer 异步提交**,所以这个 status 通常只代表
+  "已提交到 relayer / PENDING",**不可靠地代表链上已确认**。
+- **全仓搜索:前端没有任何 `getTransaction` / Soroban RPC 轮询确认上链的代码**;拿到
+  `result.hash` 后直接 `router.push` 到 receipt 页。
+- => **要真正知道"已上链",前端必须自己加 `getTransaction(hash)` 轮询**(目前没有)。
+  - 好消息:`useRozoWallet` 里已经构造了 `server`(Soroban RPC,`getNetworkDetails().sorobanRpcUrl`),
+    轮询 `getTransaction` 不需要新依赖。
+
+| 状态 | 前端现在能判断? | 怎么拿 |
+|---|---|---|
+| 签完名 + 已提交 relayer | ✅ | `result.hash` 有了 |
+| 链上已确认(payment_event 已 emit) | ❌ 目前不能 | 需新增 `getTransaction(hash)` 轮询到 SUCCESS |
+
+**`submit:true` 是 gasless relayer 提交,`result.hash` 拿到时交易"已提交"但
+**可能还没上链确认**(Soroban 合约 invoke 上链实测 14–37s)。** 两种调法:
+
+- **方案 A(推荐,先做):拿到 hash 立即 fire-and-forget 调一次 /payin。**
+  后端对"还没上链"已有兜底:Soroban RPC 点查返回 `NOT_FOUND` → 后端自动排一次 5s
+  重试 → 仍不中 → 落 cron。**最小改动,且即使没命中也不会更差**(cron 照常兜底)。
+  代价:若上链 >5s(合约常见),这一次 /payin 多半 NOT_FOUND,5s 重试也可能没到,
+  实际仍落 cron —— 即"方案 A 单独不够稳"。
+
+- **方案 B(治本,推荐叠加):等链上确认再调 /payin。**
+  `signAuthEntry({submit:true})` 后,前端**已经能拿到 hash**,可用 Soroban RPC
+  `getTransaction(hash)` 轮询到 `SUCCESS` 再调 /payin → 后端一次命中,稳定秒级。
+  - dApp 本就该给用户显示"支付中→已确认",所以这个轮询是顺带的。
+  - 但当前代码 `result.hash` 之后**直接 router.push 到 receipt 页**,没有等确认。
+    所以方案 B 要么在 receipt 页轮询确认后调,要么在 `if(result.hash)` 里先轮询。
+
+**本设计采用 A 立即调 + (可选)B 增强**:
+- v1:先做方案 A(立即 fire-and-forget),零阻塞、零风险地把能力接上。
+- v1.1(可选增强):在 `notifyPayin` 内部做"轮询 getTransaction 到 SUCCESS 再 POST,
+  最多等 ~40s,带超时",命中率更高。但要确保是后台任务(`keepalive`/不阻塞跳转)。
+
+> ⚠️ 即使方案 A 多数情况落 cron,接上它也是**净收益**:① 部分快交易能命中;
+> ② 给后端 immediate_verification 真实流量便于观测;③ 为 v1.1 打底。不接 = 永远 0 命中。
+
+### 3.4 两处插入点对称改
+- `restaurant-dapp-payment.tsx`(餐厅返现)
+- `ai-service-dapp-payment.tsx`(AI 服务)
+两处都:`generateBridgeAddress` 透传 `paymentId` + `if(result.hash)` 里调 `notifyPayin`。
+
+---
+
+## 4. 改动清单(最小)
+
+1. **新增** `src/lib/notify-payin.ts`(§3.2 的 helper)。
+2. **改** `restaurant-dapp-payment.tsx`:
+   - `generateBridgeAddress` 返回值加 `paymentId: payment.id`。
+   - `handlePayWithRozoWallet` 从 `generateBridgeAddress` 解构出 `paymentId`,在
+     `if (result.hash)` 块内 `notifyPayin(paymentId, result.hash, rozoWalletAddress)`。
+3. **改** `ai-service-dapp-payment.tsx`:同 #2 对称。
+4. **(可选)** `.env` 加 `NEXT_PUBLIC_ROZO_PAYMENT_API`(不加则用 helper 里的默认 URL)。
+
+**不改**:`useRozoWallet.transferUSDC`(它只管签名提交,职责单一,不该塞网络回调)。
+
+---
+
+## 5. 风险 / 取舍
+
+| # | 风险 | 处理 |
+|---|---|---|
+| 1 | /payin 失败/超时**阻塞支付 UI** | fire-and-forget + try/catch 静默 + `keepalive`。支付成功与否**不依赖** /payin;cron 永远兜底 |
+| 2 | `result.hash` 时交易未上链 → /payin NOT_FOUND | 后端已有 5s 重试 + cron 兜底(§3.3)。v1.1 加"等确认再调"提命中率 |
+| 3 | 跳转 receipt 页打断 fetch | `fetch({keepalive:true})` 让请求在导航后完成 |
+| 4 | paymentId 透传漏了某条支路 | 两处插入点都改;`notifyPayin` 对空 paymentId 直接 return,不报错 |
+| 5 | 安全:/payin 是公开端点,前端不带 secret | 设计上**就是**无 header(后端 `--no-verify-jwt`);txHash 是公开链上数据;后端按 memo 一对一 + 链上校验,前端只是"提示后端去查",伪造无收益 |
+| 6 | CORS | 后端是 public Edge Function(已被各端调用),CORS 允许;实施时验证浏览器直连不被拦 |
+
+> **资金安全**:前端不做任何金额/校验判断,只把 txHash 转给后端。后端 `settleContractPayin`
+> 做全部资金校验(contractId allowlist + topic + 官方 USDC + memo 一对一 + 金额闸门 + CAS)。
+> 前端报错 txHash 顶多让后端查一笔不匹配的 tx → 后端拒绝 → 无副作用。
+
+---
+
+## 6. 验证计划
+
+1. **本地编译**:`npm run build`(或 `tsc --noEmit`)通过,类型不破坏。
+2. **本地 dApp 流程**:dApp 走一笔(或 mock `window.rozo`),断言 `notifyPayin` 被调、
+   URL/body 正确(`/payments/{真实 paymentId}/payin` + `{txHash}`)。
+3. **端到端(碰链)**:真实付一笔 → 用后端 check 脚本确认走快路径:
+   ```bash
+   node <rozo-intents-api>/scripts/check-contract-payin.mjs <paymentId>
+   # 期望:✅ FAST-PATH(immediate_verification=true),而不是 🐢 CRON
+   ```
+4. **对比**:接入前后同类单的检测耗时(cron ~17-42s vs 快路径秒级)。
+
+---
+
+## 7. 待 codex review 的点
+
+- 调用时机:方案 A(立即)vs A+B(等确认)——v1 先做哪个?
+- `notifyPayin` 放 `src/lib/` 还是 `src/hooks/`?是否该用现有 api client 封装(若有)?
+- `keepalive` + router.push 的竞态:fetch 会不会被导航 abort?是否要在 push 前 await 一个极短 flush?
+- 两个支付组件是否还有第三处合约支付入口(全仓再确认有没有遗漏的 `result.hash` 点)?
+- paymentId 透传:除了 return 值,是否有更稳的方式(比如 generateBridgeAddress 返回整个 payment 对象)?
+
+---
+
+## 附:相关
+- 后端设计:`rozo-intents-api/internaldocs/20260615-stellar-contract-payin-instant-fastpath.md`
+- 后端 commit:`133b51b feat(stellar-contract): instant /payin fast-path`
+- 前端对接示例:`rozo-intents-api/scripts/payin-callback-example.md`
+- know-how 汇总:`~/workspace/rozo/todos/20260616-ROZO-slowwallet-todo.md`

--- a/docs/20260616-dapp-payin-callback-design.md
+++ b/docs/20260616-dapp-payin-callback-design.md
@@ -1,229 +1,232 @@
-# dApp /payin 回调 —— 让 Stellar 合约支付秒级确认(设计文档)
+# dApp /payin callback — make Stellar contract payments settle in seconds (design)
 
-**日期**: 2026-06-16
-**仓库**: rozo-rewards-miniapp(前端 dApp)
-**分支**: `feat/dapp-payin-callback`
-**状态**: 设计完成,待 codex review → 待实施
-**关联后端**: rozo-intents-api 已上线合约 `/payin` 即时快路径(commit `133b51b`);
-本文是让该快路径**真正被触发**的前端一环。
-
----
-
-## 0. 一句话目标
-
-用户在 dApp 里用 Rozo Wallet 付一笔 Stellar 合约支付(`pay()`),拿到 txHash 后,
-**前端立刻 `POST /payments/{id}/payin` 把 txHash 告诉后端** → 后端当场解析链上
-`payment_event` 并秒级结算,不再等每分钟 cron(实测从 ~32s → 秒级)。
+**Date**: 2026-06-16
+**Repo**: rozo-rewards-miniapp (frontend dApp)
+**Branch**: `feat/dapp-payin-callback`
+**Status**: Shipped (codex-reviewed, implemented, type-checked)
+**Backend dependency**: rozo-intents-api already shipped the instant contract `/payin`
+fast-path (commit `133b51b`). This change is the frontend half that actually *triggers* it.
 
 ---
 
-## 1. 背景:为什么现在慢
+## 0. One-line goal
 
-- 合约支付(`pay()` via Soroban)目前**只靠后端 `monitor-stellar` 每分钟 cron 轮询**
-  `getEvents` 发现 → 检测耗时 17–42s,最坏 ~60s(抖动,不是固定慢)。
-- 后端**已经上线了即时快路径**:只要有人 `POST /payments/{id}/payin` 带 txHash,
-  后端就用 Soroban RPC 点查这笔 tx 的 `payment_event`、验证、秒级结算。
-- **但当前没有任何客户端调 `/payin`**(后端实测 `immediate_verification` 全 0)→
-  快路径能力闲置,所有合约单仍走 cron 慢路径。
-- **本仓 dApp 就是真正的支付发起方**,在这里加回调是让快路径生效的最小改动。
-
-> 实证(2026-06-16):真实 ZEN 单 `1d982dc5` 第一次走 cron = 32.3s;同一笔 txHash
-> 手动调 /payin → 8.8s 且走快路径(`immediate_verification=true`)。
+When a user pays a Stellar contract payment (`pay()`) with Rozo Wallet in the dApp,
+take the resulting txHash and **immediately POST `/payments/{id}/payin`** so the
+backend point-looks-up the on-chain `payment_event` and settles in seconds, instead
+of waiting for the every-minute cron (measured: ~32s → seconds).
 
 ---
 
-## 2. 现状代码(已查证,带行号)
+## 1. Background: why it's slow today
 
-### 2.1 钱包桥:`window.rozo`
-`src/types/window.d.ts` —— native wallet 注入的 provider:
+- Contract payments (`pay()` via Soroban) are currently discovered **only by the
+  backend `monitor-stellar` cron polling `getEvents` every minute** → detection takes
+  17–42s, worst case ~60s (jitter, not a fixed slowness).
+- The backend **already shipped an instant fast-path**: as soon as someone
+  `POST /payments/{id}/payin` with a txHash, the backend point-looks-up that tx's
+  `payment_event` over Soroban RPC, validates it, and settles in seconds.
+- **But no client calls `/payin` today** (backend shows `immediate_verification` = 0)
+  → the fast-path is idle and every contract order still takes the slow cron path.
+- **This dApp is the actual payment originator.** Adding the callback here is the
+  minimal change that turns the fast-path on.
+
+> Evidence (2026-06-16): a real ZEN order `1d982dc5` took 32.3s via cron; the same
+> txHash POSTed to /payin → settled in 8.8s via the fast-path
+> (`immediate_verification=true`).
+
+---
+
+## 2. Current code (verified, with line refs)
+
+### 2.1 Wallet bridge: `window.rozo`
+`src/types/window.d.ts` — provider injected by the native wallet:
 ```ts
 window.rozo.signAuthEntry(authEntryXdr, { func, submit, message })
   : Promise<{ signedAuthEntry: string; hash: string; status: string; error?: string }>
-//                                       ^^^^ ← Stellar txHash 在这里
+//                                       ^^^^ ← Stellar txHash is here
 ```
 
-### 2.2 支付链路
-| 步骤 | 位置 | 关键 |
+### 2.2 Payment path
+| Step | Location | Key |
 |---|---|---|
-| 创建 intent | `restaurant-dapp-payment.tsx:108` `createPayment(...)` | 返回 `PaymentResponse`,**含 `id: string`(rozo paymentId UUID)** + `source.{receiverAddress, receiverMemo, amount, receiverAddressContract, receiverMemoContract}` |
-| 构建 + 提交 pay() | `useRozoWallet.ts:167-281` `transferUSDC()` | `window.rozo.signAuthEntry(..., {submit:true})` → 返回 `{ hash }` |
-| 拿到 txHash | `restaurant-dapp-payment.tsx` `handlePayWithRozoWallet` 的 `if (result.hash) {...}` | **回调插入点** |
-| AI 服务同款 | `ai-service-dapp-payment.tsx`(~157-201) | 同样的 `if (result.hash)` 块 |
+| Create intent | `restaurant-dapp-payment.tsx` `createPayment(...)` | returns `PaymentResponse`, **with `id: string` (rozo paymentId UUID)** + `source.{receiverAddress, receiverMemo, amount, receiverAddressContract, receiverMemoContract}` |
+| Build + submit pay() | `useRozoWallet.ts` `transferUSDC()` | `window.rozo.signAuthEntry(..., {submit:true})` → returns `{ hash }` |
+| Get txHash | `restaurant-dapp-payment.tsx` `handlePayWithRozoWallet`, the `if (result.hash) {...}` block | **callback insertion point** |
+| AI-service twin | `ai-service-dapp-payment.tsx` | same `if (result.hash)` block |
 
-### 2.3 🔴 关键缺口(本设计的核心改动点)
-`generateBridgeAddress()`(`restaurant-dapp-payment.tsx:100-137`)拿到 `payment` 后
-**只 return 了 5 个字段,把 `payment.id` 丢弃了**:
+### 2.3 The key gap (the core change)
+`generateBridgeAddress()` (`restaurant-dapp-payment.tsx`) took the `payment` and
+**returned only 5 fields, dropping `payment.id`**:
 ```ts
-const payment = await createPayment({...});   // payment.id 是 rozo paymentId
+const payment = await createPayment({...});   // payment.id is the rozo paymentId
 return {
   amount: payment.source.amount,
   bridgeAddress: payment.source.receiverAddress,
   memo: payment.source.receiverMemo,
   receiverAddressContract: payment.source.receiverAddressContract,
   receiverMemoContract: payment.source.receiverMemoContract,
-  // ❌ payment.id 没透传出来
+  // ❌ payment.id was not plumbed out
 };
 ```
-=> 要调 `/payments/{id}/payin`,**必须先把 `payment.id` 从 `generateBridgeAddress`
-透传到 `handlePayWithRozoWallet`**。这是改动的第一块。
+To call `/payments/{id}/payin` we **must plumb `payment.id` out of
+`generateBridgeAddress` into `handlePayWithRozoWallet`**. That's change #1.
 
-### 2.4 后端接口(rozo-intents-api,已上线)
+### 2.4 Backend endpoint (rozo-intents-api, already live)
 | | |
 |---|---|
-| Method/Path | `POST /payments/{paymentId}/payin` |
-| Base URL | `https://aozudqtlykbhzbuzalzz.supabase.co/functions/v1/payment-api` |
-| Auth | **无需任何 header**(函数 `--no-verify-jwt`) |
-| Body | `{ "txHash": "<stellar_tx_hash>", "fromAddress": "<可选>" }` |
-| 合约单成功响应 | `{ "message": "Payin registered (contract fast-path)", ... }` |
+| Method/Path | `POST /payment-api/payments/{paymentId}/payin` |
+| Base URL | `https://intentapiv4.rozo.ai/functions/v1` (the SDK default; same backend `createPayment` uses) |
+| Auth | **none** (function deployed `--no-verify-jwt`) |
+| Body | `{ "txHash": "<stellar_tx_hash>", "fromAddress"/"senderAddress": "<optional>" }` |
+| Contract-order success | `{ "message": "Payin registered (contract fast-path)", ... }` |
 
 ---
 
-## 3. 设计
+## 3. Design
 
-### 3.1 数据流(改后)
+### 3.1 Data flow (after)
 ```
 handlePayWithRozoWallet
-  ├─ generateBridgeAddress()  → 现在额外返回 paymentId (= payment.id)
+  ├─ generateBridgeAddress()  → now also returns paymentId (= payment.id)
   ├─ transferUSDC()           → result.hash (txHash)
   └─ if (result.hash):
-       ├─ notifyPayin(paymentId, result.hash)   ← 新增:POST /payin(fire-and-forget,不阻塞 UI)
-       ├─ savePaymentReceipt(...)               ← 原有
-       ├─ capture(PAYMENT_COMPLETED)            ← 原有
-       └─ router.push(/receipt...)              ← 原有
+       ├─ notifyPayin(paymentId, result.hash, fromAddress)  ← NEW: fire-and-forget, before router.push
+       ├─ savePaymentReceipt(...)               ← existing
+       ├─ capture(PAYMENT_COMPLETED)            ← existing
+       └─ router.push(/receipt...)              ← existing
 ```
 
-### 3.2 新增一个薄 helper:`src/lib/notify-payin.ts`
-```ts
-// 把 txHash 报给后端,触发合约即时快路径。fire-and-forget:绝不阻塞/打断支付 UI。
-const PAYMENT_API_BASE =
-  process.env.NEXT_PUBLIC_ROZO_PAYMENT_API ??
-  "https://aozudqtlykbhzbuzalzz.supabase.co/functions/v1/payment-api";
+### 3.2 The helper: `src/lib/notify-payin.ts`
+Uses the SDK's `updatePaymentPayInTxHash` from `@rozoai/intent-common` rather than a
+hand-rolled `fetch`. This matters: the SDK function posts to
+`/payment-api/payments/{id}/payin` through the **same `apiClient` base URL that
+`createPayment` used** (`intentapiv4.rozo.ai` by default). The `/payin` call MUST hit
+the same backend that created the payment, or the paymentId won't exist there —
+sharing the SDK apiClient guarantees they never drift apart.
 
-export async function notifyPayin(
-  paymentId: string,
-  txHash: string,
+```ts
+import { updatePaymentPayInTxHash } from "@rozoai/intent-common";
+
+export function notifyPayin(
+  paymentId: string | undefined,
+  txHash: string | undefined,
   fromAddress?: string,
-): Promise<void> {
+): void {
   if (!paymentId || !txHash) return;
   try {
-    await fetch(`${PAYMENT_API_BASE}/payments/${paymentId}/payin`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ txHash, fromAddress }),
-      keepalive: true, // 让请求在页面跳转(router.push)后仍能完成
-    });
-  } catch {
-    // 后端 cron 是兜底,这里失败不影响支付成功;静默吞掉(不打断用户)
+    // No await: kick off synchronously so it's queued before router.push.
+    void updatePaymentPayInTxHash({ paymentId, txHash, senderAddress: fromAddress })
+      .catch((err) => {
+        console.warn("[notifyPayin] fast-path hint failed (cron will back it up):", err);
+      });
+  } catch (err) {
+    console.warn("[notifyPayin] fast-path hint threw (cron will back it up):", err);
   }
 }
 ```
 
-### 3.3 调用时机(关键 —— 决定能不能命中快路径)
+### 3.3 Timing — Plan A (immediate fire-and-forget), no on-chain wait
 
-#### 🔴 前端能区分"签完名/已提交" vs "已上链确认"吗?——目前**不能**(实测)
-- `transferUSDC` 返回 `TransferResult { hash, status, signedAuthEntry }`(`useRozoWallet.ts:54`)。
-- `result.status` 是 native wallet relayer 返回的**裸字符串**(`window.d.ts:48` `status: string`,
-  无枚举约束)。`submit:true` 是 **relayer 异步提交**,所以这个 status 通常只代表
-  "已提交到 relayer / PENDING",**不可靠地代表链上已确认**。
-- **全仓搜索:前端没有任何 `getTransaction` / Soroban RPC 轮询确认上链的代码**;拿到
-  `result.hash` 后直接 `router.push` 到 receipt 页。
-- => **要真正知道"已上链",前端必须自己加 `getTransaction(hash)` 轮询**(目前没有)。
-  - 好消息:`useRozoWallet` 里已经构造了 `server`(Soroban RPC,`getNetworkDetails().sorobanRpcUrl`),
-    轮询 `getTransaction` 不需要新依赖。
+The frontend does **no amount logic and no on-chain waiting**. The backend owns both:
 
-| 状态 | 前端现在能判断? | 怎么拿 |
+- **Amount tiering** (`FASTPATH_AMOUNT_GATE_USD`, currently $20): on-chain amount
+  ≤ $20 settles instantly; > $20 defers to cron. This is a blast-radius gate, not a
+  correctness gate — the safety anchor is contractId allowlist + topic + official USDC
+  + 1:1 memo + amount match + CAS idempotency.
+- **"tx not yet on-chain"**: `signAuthEntry({submit:true})` is a gasless relayer submit,
+  so `result.hash` can come back before the tx is indexed (Soroban contract invoke
+  takes ~14–37s on-chain). The backend handles this with a three-layer fallback:
+  point-lookup returns `NOT_FOUND` → backend schedules one 5s recheck → still missing
+  → the every-minute cron is the final backstop.
+
+So the frontend just fires the hint immediately and moves on. Even when the hint lands
+before the tx is indexed, it's still a net win: some fast txs hit instantly, the backend
+gets real `immediate_verification` traffic, and cron always backs it up.
+
+> We do NOT poll `getTransaction` to confirm on-chain before calling /payin. `result.status`
+> is an unconstrained relayer string and doesn't reliably mean "confirmed", and the
+> backend's own fallback already covers the not-yet-indexed case. Adding a frontend poll
+> would be more code for marginal benefit.
+
+### 3.4 Both insertion points changed symmetrically
+- `restaurant-dapp-payment.tsx` (restaurant cashback)
+- `ai-service-dapp-payment.tsx` (AI services)
+
+Both: plumb `paymentId` out of `generateBridgeAddress`, then call `notifyPayin` inside
+the `if (result.hash)` block, **before** `router.push`. A repo-wide grep confirmed these
+are the **only two** contract-payment entry points (only these two use
+`result.hash` / `generateBridgeAddress`).
+
+---
+
+## 4. Change list (minimal)
+
+1. **New** `src/lib/notify-payin.ts` (§3.2).
+2. **Edit** `restaurant-dapp-payment.tsx`:
+   - `generateBridgeAddress` return value gains `paymentId: payment.id`.
+   - `handlePayWithRozoWallet` destructures `paymentId`, calls
+     `notifyPayin(paymentId, result.hash, rozoWalletAddress ?? undefined)` in the
+     `if (result.hash)` block before `router.push`.
+3. **Edit** `ai-service-dapp-payment.tsx`: symmetric to #2.
+
+**Not changed**: `useRozoWallet.transferUSDC` (it only signs + submits; it should not own
+a network callback).
+
+---
+
+## 5. Risks / trade-offs
+
+| # | Risk | Handling |
 |---|---|---|
-| 签完名 + 已提交 relayer | ✅ | `result.hash` 有了 |
-| 链上已确认(payment_event 已 emit) | ❌ 目前不能 | 需新增 `getTransaction(hash)` 轮询到 SUCCESS |
+| 1 | /payin failure/timeout **blocks payment UI** | fire-and-forget + try/catch + no await. Payment success does **not** depend on /payin; cron always backs it up |
+| 2 | `result.hash` exists but tx not on-chain yet → /payin NOT_FOUND | backend 5s recheck + cron backstop (§3.3) |
+| 3 | Navigating to receipt cuts off the request | request is kicked off synchronously before `router.push`; the underlying SDK call keeps running across SPA navigation |
+| 4 | paymentId missed on some path | both insertion points changed; `notifyPayin` no-ops on empty paymentId |
+| 5 | Security: /payin is a no-header public endpoint, frontend sends no secret | by design (backend `--no-verify-jwt`). txHash is public on-chain data; backend validates memo 1:1 with the order + official USDC issuer, so a forged/wrong txHash just makes the backend look up a non-matching tx → it rejects, no side effect |
+| 6 | Wrong backend / URL drift | use the SDK's `updatePaymentPayInTxHash` (same apiClient as `createPayment`), so /payin can't point at a different backend than the one that created the payment |
 
-**`submit:true` 是 gasless relayer 提交,`result.hash` 拿到时交易"已提交"但
-**可能还没上链确认**(Soroban 合约 invoke 上链实测 14–37s)。** 两种调法:
-
-- **方案 A(推荐,先做):拿到 hash 立即 fire-and-forget 调一次 /payin。**
-  后端对"还没上链"已有兜底:Soroban RPC 点查返回 `NOT_FOUND` → 后端自动排一次 5s
-  重试 → 仍不中 → 落 cron。**最小改动,且即使没命中也不会更差**(cron 照常兜底)。
-  代价:若上链 >5s(合约常见),这一次 /payin 多半 NOT_FOUND,5s 重试也可能没到,
-  实际仍落 cron —— 即"方案 A 单独不够稳"。
-
-- **方案 B(治本,推荐叠加):等链上确认再调 /payin。**
-  `signAuthEntry({submit:true})` 后,前端**已经能拿到 hash**,可用 Soroban RPC
-  `getTransaction(hash)` 轮询到 `SUCCESS` 再调 /payin → 后端一次命中,稳定秒级。
-  - dApp 本就该给用户显示"支付中→已确认",所以这个轮询是顺带的。
-  - 但当前代码 `result.hash` 之后**直接 router.push 到 receipt 页**,没有等确认。
-    所以方案 B 要么在 receipt 页轮询确认后调,要么在 `if(result.hash)` 里先轮询。
-
-**本设计采用 A 立即调 + (可选)B 增强**:
-- v1:先做方案 A(立即 fire-and-forget),零阻塞、零风险地把能力接上。
-- v1.1(可选增强):在 `notifyPayin` 内部做"轮询 getTransaction 到 SUCCESS 再 POST,
-  最多等 ~40s,带超时",命中率更高。但要确保是后台任务(`keepalive`/不阻塞跳转)。
-
-> ⚠️ 即使方案 A 多数情况落 cron,接上它也是**净收益**:① 部分快交易能命中;
-> ② 给后端 immediate_verification 真实流量便于观测;③ 为 v1.1 打底。不接 = 永远 0 命中。
-
-### 3.4 两处插入点对称改
-- `restaurant-dapp-payment.tsx`(餐厅返现)
-- `ai-service-dapp-payment.tsx`(AI 服务)
-两处都:`generateBridgeAddress` 透传 `paymentId` + `if(result.hash)` 里调 `notifyPayin`。
+> **Funds safety**: the frontend makes no amount/validation decisions, it only forwards
+> the txHash. The backend `settleContractPayin` runs the full validation chain
+> (contractId allowlist + topic + official USDC + 1:1 memo + amount gate + CAS). A bad
+> txHash from the frontend at most makes the backend look up a non-matching tx → rejected.
 
 ---
 
-## 4. 改动清单(最小)
+## 6. Verification
 
-1. **新增** `src/lib/notify-payin.ts`(§3.2 的 helper)。
-2. **改** `restaurant-dapp-payment.tsx`:
-   - `generateBridgeAddress` 返回值加 `paymentId: payment.id`。
-   - `handlePayWithRozoWallet` 从 `generateBridgeAddress` 解构出 `paymentId`,在
-     `if (result.hash)` 块内 `notifyPayin(paymentId, result.hash, rozoWalletAddress)`。
-3. **改** `ai-service-dapp-payment.tsx`:同 #2 对称。
-4. **(可选)** `.env` 加 `NEXT_PUBLIC_ROZO_PAYMENT_API`(不加则用 helper 里的默认 URL)。
-
-**不改**:`useRozoWallet.transferUSDC`(它只管签名提交,职责单一,不该塞网络回调)。
-
----
-
-## 5. 风险 / 取舍
-
-| # | 风险 | 处理 |
-|---|---|---|
-| 1 | /payin 失败/超时**阻塞支付 UI** | fire-and-forget + try/catch 静默 + `keepalive`。支付成功与否**不依赖** /payin;cron 永远兜底 |
-| 2 | `result.hash` 时交易未上链 → /payin NOT_FOUND | 后端已有 5s 重试 + cron 兜底(§3.3)。v1.1 加"等确认再调"提命中率 |
-| 3 | 跳转 receipt 页打断 fetch | `fetch({keepalive:true})` 让请求在导航后完成 |
-| 4 | paymentId 透传漏了某条支路 | 两处插入点都改;`notifyPayin` 对空 paymentId 直接 return,不报错 |
-| 5 | 安全:/payin 是公开端点,前端不带 secret | 设计上**就是**无 header(后端 `--no-verify-jwt`);txHash 是公开链上数据;后端按 memo 一对一 + 链上校验,前端只是"提示后端去查",伪造无收益 |
-| 6 | CORS | 后端是 public Edge Function(已被各端调用),CORS 允许;实施时验证浏览器直连不被拦 |
-
-> **资金安全**:前端不做任何金额/校验判断,只把 txHash 转给后端。后端 `settleContractPayin`
-> 做全部资金校验(contractId allowlist + topic + 官方 USDC + memo 一对一 + 金额闸门 + CAS)。
-> 前端报错 txHash 顶多让后端查一笔不匹配的 tx → 后端拒绝 → 无副作用。
-
----
-
-## 6. 验证计划
-
-1. **本地编译**:`npm run build`(或 `tsc --noEmit`)通过,类型不破坏。
-2. **本地 dApp 流程**:dApp 走一笔(或 mock `window.rozo`),断言 `notifyPayin` 被调、
-   URL/body 正确(`/payments/{真实 paymentId}/payin` + `{txHash}`)。
-3. **端到端(碰链)**:真实付一笔 → 用后端 check 脚本确认走快路径:
+1. **Type check**: `npx tsc --noEmit` — the three changed files have zero errors
+   (only the pre-existing, unrelated `posthog-js` module-not-found remains).
+2. **Lint**: pre-commit ESLint clean on all three files.
+3. **End-to-end (on-chain)**: pay a real contract order → confirm it took the fast-path
+   with the backend check script:
    ```bash
    node <rozo-intents-api>/scripts/check-contract-payin.mjs <paymentId>
-   # 期望:✅ FAST-PATH(immediate_verification=true),而不是 🐢 CRON
+   # expect: ✅ FAST-PATH (immediate_verification=true), not 🐢 CRON
    ```
-4. **对比**:接入前后同类单的检测耗时(cron ~17-42s vs 快路径秒级)。
+4. **Compare**: detection latency before/after for similar orders (cron ~17–42s vs
+   fast-path seconds).
 
 ---
 
-## 7. 待 codex review 的点
+## 7. codex review outcome (2026-06-16)
 
-- 调用时机:方案 A(立即)vs A+B(等确认)——v1 先做哪个?
-- `notifyPayin` 放 `src/lib/` 还是 `src/hooks/`?是否该用现有 api client 封装(若有)?
-- `keepalive` + router.push 的竞态:fetch 会不会被导航 abort?是否要在 push 前 await 一个极短 flush?
-- 两个支付组件是否还有第三处合约支付入口(全仓再确认有没有遗漏的 `result.hash` 点)?
-- paymentId 透传:除了 return 值,是否有更稳的方式(比如 generateBridgeAddress 返回整个 payment 对象)?
+Reviewed via `codex exec` on the 5 design points. Result: **4 PASS, 1 must-fix (applied)**.
+
+- **keepalive / timing** — PASS. This is SPA navigation, not document unload; a fetch
+  already started keeps running. (Final impl uses the SDK call, same property.)
+- **paymentId plumbing** — PASS. Direct and robust at both call sites.
+- **failure logging** — was FAIL, now fixed. The original hand-rolled `.catch()` only
+  caught network/CORS/abort; an HTTP 4xx/5xx resolves and would've been silent. Fixed
+  (and the SDK refactor makes the SDK own response handling).
+- **third entry point** — PASS. grep confirms only the two components submit payments.
+- **security boundary** — PASS. Public /payin with no secret is correct as long as the
+  backend validates id/contract/asset/memo/amount/idempotency, which it does. Treat
+  `fromAddress` as advisory only.
 
 ---
 
-## 附:相关
-- 后端设计:`rozo-intents-api/internaldocs/20260615-stellar-contract-payin-instant-fastpath.md`
-- 后端 commit:`133b51b feat(stellar-contract): instant /payin fast-path`
-- 前端对接示例:`rozo-intents-api/scripts/payin-callback-example.md`
-- know-how 汇总:`~/workspace/rozo/todos/20260616-ROZO-slowwallet-todo.md`
+## Appendix: related
+- Backend design: `rozo-intents-api/internaldocs/20260615-stellar-contract-payin-instant-fastpath.md`
+- Backend commit: `133b51b feat(stellar-contract): instant /payin fast-path`
+- Backend integration example: `rozo-intents-api/scripts/payin-callback-example.md`

--- a/src/components/ai-services/ai-service-dapp-payment.tsx
+++ b/src/components/ai-services/ai-service-dapp-payment.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useRozoWallet } from "@/hooks/useRozoWallet";
 import { capture } from "@/lib/analytics/index";
 import { PAYMENT_EVENTS } from "@/lib/analytics/events";
+import { notifyPayin } from "@/lib/notify-payin";
 import {
   formatRozoErrorMessage,
   isRozoProviderError,
@@ -91,6 +92,7 @@ export function AiServiceDappPayment({
   const generateBridgeAddress = async (
     amount: string,
   ): Promise<{
+    paymentId: string;
     amount: string;
     bridgeAddress: string;
     memo: string;
@@ -118,6 +120,7 @@ export function AiServiceDappPayment({
     }
 
     return {
+      paymentId: payment.id,
       amount: payment.source.amount,
       bridgeAddress: payment.source.receiverAddress,
       memo: payment.source.receiverMemo,
@@ -151,7 +154,7 @@ export function AiServiceDappPayment({
         order_id: merchantOrderId,
       });
 
-      const { amount, receiverAddressContract, receiverMemoContract } =
+      const { paymentId, amount, receiverAddressContract, receiverMemoContract } =
         await generateBridgeAddress(usdAmount);
 
       const result = await rozoWalletTransfer(
@@ -196,6 +199,11 @@ export function AiServiceDappPayment({
           amount_usd: usdAmount,
           order_id: merchantOrderId,
         });
+
+        // Hint the backend to settle this contract payin instantly (fast-path)
+        // instead of waiting for the every-minute cron. Fire-and-forget, kicked
+        // off BEFORE router.push so keepalive carries it across the navigation.
+        notifyPayin(paymentId, result.hash, rozoWalletAddress ?? undefined);
 
         toast.success(`Payment successful to ${service.name}!`);
         router.push(`/receipt?payment_id=${merchantOrderId}`);

--- a/src/components/restaurant/restaurant-dapp-payment.tsx
+++ b/src/components/restaurant/restaurant-dapp-payment.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { useRozoWallet } from "@/hooks/useRozoWallet";
 import { capture } from "@/lib/analytics/index";
 import { PAYMENT_EVENTS } from "@/lib/analytics/events";
+import { notifyPayin } from "@/lib/notify-payin";
 import { savePaymentReceipt } from "@/lib/payment-storage";
 import {
   formatRozoErrorMessage,
@@ -97,6 +98,7 @@ export function RestaurantDappPayment({
     amountLocal: string;
     currencyLocal: string;
   }): Promise<{
+    paymentId: string;
     amount: string;
     bridgeAddress: string;
     memo: string;
@@ -126,6 +128,7 @@ export function RestaurantDappPayment({
     }
 
     return {
+      paymentId: payment.id,
       amount: payment.source.amount,
       bridgeAddress: payment.source.receiverAddress,
       memo: payment.source.receiverMemo,
@@ -157,7 +160,7 @@ export function RestaurantDappPayment({
       });
 
       // Transfer USDC on Stellar network
-      const { amount, receiverAddressContract, receiverMemoContract } =
+      const { paymentId, amount, receiverAddressContract, receiverMemoContract } =
         await generateBridgeAddress({
           amountUsd: usdAmount,
           amountLocal: paymentAmount,
@@ -209,6 +212,11 @@ export function RestaurantDappPayment({
           amount_usd: usdAmount,
           order_id: merchantOrderId,
         });
+
+        // Hint the backend to settle this contract payin instantly (fast-path)
+        // instead of waiting for the every-minute cron. Fire-and-forget, kicked
+        // off BEFORE router.push so keepalive carries it across the navigation.
+        notifyPayin(paymentId, result.hash, rozoWalletAddress ?? undefined);
 
         toast.success(`Payment successful to ${restaurant.name}!`);
         router.push(

--- a/src/lib/notify-payin.ts
+++ b/src/lib/notify-payin.ts
@@ -1,12 +1,17 @@
-// notify-payin: report the on-chain txHash to the Rozo backend so a Stellar
-// CONTRACT payment settles via the instant fast-path instead of waiting for the
-// every-minute cron (17-42s).
+// notify-payin: report the on-chain txHash to the Rozo intents backend so a
+// Stellar CONTRACT payment settles via the instant fast-path instead of waiting
+// for the every-minute cron (17-42s).
 //
-// Trigger contract (backend, rozo-intents-api, already shipped — commit 133b51b):
-//   POST /payments/{id}/payin  body { txHash, fromAddress? }  — NO auth header.
-// The backend point-looks-up the tx's payment_event over Soroban RPC, runs the
-// full validation chain (contractId allowlist + topic + official USDC + 1:1 memo
-// + amount gate + CAS), and settles in seconds. On-chain amount <= $20 settles
+// Uses the SDK's updatePaymentPayInTxHash (POST /payment-api/payments/{id}/payin)
+// rather than a hand-rolled fetch. That matters: it shares the SAME apiClient base
+// URL that createPayment used (intentapiv4.rozo.ai by default), so the /payin call
+// can never drift to a different backend than the one that created the payment —
+// otherwise the paymentId wouldn't exist there.
+//
+// Backend trigger contract (rozo-intents-api, already shipped — commit 133b51b):
+// it point-looks-up the tx's payment_event over Soroban RPC, runs the full
+// validation chain (contractId allowlist + topic + official USDC + 1:1 memo +
+// amount gate + CAS), and settles in seconds. On-chain amount <= $20 settles
 // instantly; > $20 defers to cron. If the tx is not yet indexed (we fired before
 // confirmation) the backend schedules one 5s recheck, then cron is the backstop.
 //
@@ -17,21 +22,20 @@
 // SECURITY: /payin takes no secret by design. txHash is public on-chain data; the
 // backend settles purely on its own validation (memo is 1:1 with the order, asset
 // must be the official USDC issuer), so a forged/wrong txHash just makes the backend
-// look up a tx that doesn't match this order → it rejects, no side effect.
+// look up a tx that doesn't match this order -> it rejects, no side effect.
 
-const PAYMENT_API_BASE =
-  process.env.NEXT_PUBLIC_ROZO_PAYMENT_API ??
-  "https://aozudqtlykbhzbuzalzz.supabase.co/functions/v1/payment-api";
+import { updatePaymentPayInTxHash } from "@rozoai/intent-common";
 
 /**
  * Tell the backend to settle a contract payin immediately.
  *
  * Returns nothing and never throws — call it WITHOUT await right before navigating
- * away. `keepalive: true` lets the request outlive the page transition (router.push).
+ * away. The underlying request is kicked off synchronously so it's queued before
+ * the caller navigates (router.push).
  *
  * @param paymentId Rozo payment UUID (PaymentResponse.id). No-op if falsy.
  * @param txHash    Stellar contract pay() tx hash (64 hex, no 0x). No-op if falsy.
- * @param fromAddress Optional payer address; backend works without it.
+ * @param fromAddress Optional payer address; backend works without it (advisory).
  */
 export function notifyPayin(
   paymentId: string | undefined,
@@ -40,29 +44,17 @@ export function notifyPayin(
 ): void {
   if (!paymentId || !txHash) return;
   try {
-    // No await: kick off the request synchronously so it's queued in the network
-    // stack before the caller navigates. keepalive keeps it alive across the nav.
-    void fetch(`${PAYMENT_API_BASE}/payments/${paymentId}/payin`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ txHash, fromAddress }),
-      keepalive: true,
-    })
-      .then((res) => {
-        // A 4xx/5xx RESOLVES (fetch only rejects on network/CORS/abort), so an
-        // HTTP error would be fully silent without this check. Cron still backs
-        // it up, so we only log — never surface to UI.
-        if (!res.ok) {
-          console.warn(
-            `[notifyPayin] fast-path hint got HTTP ${res.status} (cron will back it up)`,
-          );
-        }
-      })
-      .catch((err) => {
-        // Network/CORS/abort. Cron is the backstop, so a failed hint never costs
-        // a payment. Log for observability, never surface to UI.
-        console.warn("[notifyPayin] fast-path hint failed (cron will back it up):", err);
-      });
+    // No await: kick off the request synchronously so it's queued before the
+    // caller navigates. Cron is the backstop, so any failure only gets logged.
+    void updatePaymentPayInTxHash({
+      paymentId,
+      txHash,
+      senderAddress: fromAddress,
+    }).catch((err) => {
+      // Network/HTTP error. A failed hint never costs a payment (cron backs it
+      // up), so log for observability but never surface to the UI.
+      console.warn("[notifyPayin] fast-path hint failed (cron will back it up):", err);
+    });
   } catch (err) {
     // Defensive: even constructing the request must not break the payment flow.
     console.warn("[notifyPayin] fast-path hint threw (cron will back it up):", err);

--- a/src/lib/notify-payin.ts
+++ b/src/lib/notify-payin.ts
@@ -30,8 +30,8 @@ import { updatePaymentPayInTxHash } from "@rozoai/intent-common";
  * Tell the backend to settle a contract payin immediately.
  *
  * Returns nothing and never throws — call it WITHOUT await right before navigating
- * away. The underlying request is kicked off synchronously so it's queued before
- * the caller navigates (router.push).
+ * away. The request is kicked off synchronously so it's in flight before the caller
+ * navigates (router.push); an in-flight SPA navigation does not cancel it.
  *
  * @param paymentId Rozo payment UUID (PaymentResponse.id). No-op if falsy.
  * @param txHash    Stellar contract pay() tx hash (64 hex, no 0x). No-op if falsy.
@@ -44,17 +44,30 @@ export function notifyPayin(
 ): void {
   if (!paymentId || !txHash) return;
   try {
-    // No await: kick off the request synchronously so it's queued before the
+    // No await: kick off the request synchronously so it's in flight before the
     // caller navigates. Cron is the backstop, so any failure only gets logged.
     void updatePaymentPayInTxHash({
       paymentId,
       txHash,
       senderAddress: fromAddress,
-    }).catch((err) => {
-      // Network/HTTP error. A failed hint never costs a payment (cron backs it
-      // up), so log for observability but never surface to the UI.
-      console.warn("[notifyPayin] fast-path hint failed (cron will back it up):", err);
-    });
+    })
+      .then((res) => {
+        // The SDK NEVER rejects: fetchApi catches HTTP 4xx/5xx and network errors
+        // internally and resolves { data: null, error, status: null }. So a .catch()
+        // alone would silently treat a backend rejection as success — we must inspect
+        // res.error / res.data here. Cron backs it up, so we only log, never surface.
+        if (res?.error || !res?.data) {
+          console.warn(
+            "[notifyPayin] fast-path hint not accepted (cron will back it up):",
+            res?.error ?? `status=${res?.status ?? "unknown"}`,
+          );
+        }
+      })
+      .catch((err) => {
+        // Defensive: SDK shouldn't reject, but if a future version does, don't let
+        // it become an unhandled rejection.
+        console.warn("[notifyPayin] fast-path hint threw (cron will back it up):", err);
+      });
   } catch (err) {
     // Defensive: even constructing the request must not break the payment flow.
     console.warn("[notifyPayin] fast-path hint threw (cron will back it up):", err);

--- a/src/lib/notify-payin.ts
+++ b/src/lib/notify-payin.ts
@@ -1,0 +1,70 @@
+// notify-payin: report the on-chain txHash to the Rozo backend so a Stellar
+// CONTRACT payment settles via the instant fast-path instead of waiting for the
+// every-minute cron (17-42s).
+//
+// Trigger contract (backend, rozo-intents-api, already shipped — commit 133b51b):
+//   POST /payments/{id}/payin  body { txHash, fromAddress? }  — NO auth header.
+// The backend point-looks-up the tx's payment_event over Soroban RPC, runs the
+// full validation chain (contractId allowlist + topic + official USDC + 1:1 memo
+// + amount gate + CAS), and settles in seconds. On-chain amount <= $20 settles
+// instantly; > $20 defers to cron. If the tx is not yet indexed (we fired before
+// confirmation) the backend schedules one 5s recheck, then cron is the backstop.
+//
+// FIRE-AND-FORGET: this must NEVER block or break the payment UI. The payment is
+// already successful once the wallet returns a hash; /payin is only a "hey backend,
+// go look at this tx now" hint. Cron is the safety net if this call never lands.
+//
+// SECURITY: /payin takes no secret by design. txHash is public on-chain data; the
+// backend settles purely on its own validation (memo is 1:1 with the order, asset
+// must be the official USDC issuer), so a forged/wrong txHash just makes the backend
+// look up a tx that doesn't match this order → it rejects, no side effect.
+
+const PAYMENT_API_BASE =
+  process.env.NEXT_PUBLIC_ROZO_PAYMENT_API ??
+  "https://aozudqtlykbhzbuzalzz.supabase.co/functions/v1/payment-api";
+
+/**
+ * Tell the backend to settle a contract payin immediately.
+ *
+ * Returns nothing and never throws — call it WITHOUT await right before navigating
+ * away. `keepalive: true` lets the request outlive the page transition (router.push).
+ *
+ * @param paymentId Rozo payment UUID (PaymentResponse.id). No-op if falsy.
+ * @param txHash    Stellar contract pay() tx hash (64 hex, no 0x). No-op if falsy.
+ * @param fromAddress Optional payer address; backend works without it.
+ */
+export function notifyPayin(
+  paymentId: string | undefined,
+  txHash: string | undefined,
+  fromAddress?: string,
+): void {
+  if (!paymentId || !txHash) return;
+  try {
+    // No await: kick off the request synchronously so it's queued in the network
+    // stack before the caller navigates. keepalive keeps it alive across the nav.
+    void fetch(`${PAYMENT_API_BASE}/payments/${paymentId}/payin`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ txHash, fromAddress }),
+      keepalive: true,
+    })
+      .then((res) => {
+        // A 4xx/5xx RESOLVES (fetch only rejects on network/CORS/abort), so an
+        // HTTP error would be fully silent without this check. Cron still backs
+        // it up, so we only log — never surface to UI.
+        if (!res.ok) {
+          console.warn(
+            `[notifyPayin] fast-path hint got HTTP ${res.status} (cron will back it up)`,
+          );
+        }
+      })
+      .catch((err) => {
+        // Network/CORS/abort. Cron is the backstop, so a failed hint never costs
+        // a payment. Log for observability, never surface to UI.
+        console.warn("[notifyPayin] fast-path hint failed (cron will back it up):", err);
+      });
+  } catch (err) {
+    // Defensive: even constructing the request must not break the payment flow.
+    console.warn("[notifyPayin] fast-path hint threw (cron will back it up):", err);
+  }
+}


### PR DESCRIPTION
## What

Wire the dApp payment flow to notify the Rozo intents backend the moment a Stellar contract payment returns a txHash, so contract payins settle in **seconds** instead of waiting for the every-minute cron (measured ~17–42s, worst case ~60s).

The backend already shipped the instant `/payin` fast-path (rozo-intents-api commit `133b51b`), but **no client was calling it** — so the capability sat idle and every contract order took the slow cron path. This PR is the frontend half that turns it on.

> Evidence: real ZEN order `1d982dc5` took 32.3s via cron; the same txHash POSTed to `/payin` settled in 8.8s via the fast-path.

## Changes

- **New `src/lib/notify-payin.ts`** — fire-and-forget hint to the backend. Uses the SDK's `updatePaymentPayInTxHash` from `@rozoai/intent-common`, which posts to `/payment-api/payments/{id}/payin` via the **same apiClient base URL that `createPayment` uses** (`intentapiv4.rozo.ai`). This guarantees `/payin` hits the same backend that created the payment — otherwise the paymentId wouldn't exist there.
- **`restaurant-dapp-payment.tsx` + `ai-service-dapp-payment.tsx`** (the only two contract-payment entry points) — plumb `payment.id` out of `generateBridgeAddress` and call `notifyPayin` in the `if (result.hash)` block, kicked off synchronously before `router.push`.
- **`docs/20260616-dapp-payin-callback-design.md`** — design doc.

## Design notes

- **Frontend does no amount logic and no on-chain waiting.** The backend owns amount tiering (on-chain ≤ \$20 settles instantly / > \$20 defers to cron) and the not-yet-on-chain case (NOT_FOUND → 5s recheck → cron backstop).
- **Fire-and-forget, never blocks the UI.** Payment success does not depend on `/payin`; cron is always the backstop. Failures are logged (`console.warn`), never surfaced to the user.
- **Security**: `/payin` is a no-header public endpoint by design. txHash is public on-chain data; the backend validates contractId allowlist + topic + official USDC issuer + 1:1 memo + amount gate + CAS idempotency. A forged/wrong txHash just makes the backend look up a non-matching tx → rejected, no side effect.

## Verification

- `npx tsc --noEmit` — zero errors in the three changed files (only the pre-existing, unrelated `posthog-js` module-not-found remains).
- Pre-commit ESLint clean on all three files.
- codex-reviewed (5 points: 4 PASS, 1 must-fix applied — log non-2xx responses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)