### PR TITLE
fix(images): allow dcdn.rozo.ai in next/image remotePatterns

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,7 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "cdn1.npcdn.net" },
       { protocol: "https", hostname: "ns.com" },
       { protocol: "https", hostname: "www.rozo.ai" },
+      { protocol: "https", hostname: "dcdn.rozo.ai" },
     ],
   },
   async redirects() {


### PR DESCRIPTION
## Problem

Merchant logos on the landing page render as broken images (NS Cafe in `Featured Merchant`, etc.).

Root cause: logos were migrated to the `dcdn.rozo.ai` CDN (`src/lib/data.ts` — NS Cafe, Ride, Rozo Studio) in the recent "serve logo from dcdn.rozo.ai CDN" changes, but `dcdn.rozo.ai` was never added to `images.remotePatterns` in `next.config.ts`. The Next.js image optimizer returns `400 Bad Request` for any host not on the allowlist, so `<Image>` fails to load these logos.

The CDN files themselves are healthy:
- `https://dcdn.rozo.ai/ns-logo.webp` → `200 image/webp`
- `https://dcdn.rozo.ai/limousine.webp` → `200 image/webp`
- `https://dcdn.rozo.ai/rozo-logo.webp` → `200 image/webp`

Verified against production: `/_next/image?url=<dcdn url>` returns `400` (blocked), while an allowlisted host returns `200`.

## Fix

Add `dcdn.rozo.ai` to `images.remotePatterns`. One line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)