### PR TITLE
fix(landing): copy tweaks + Base app ownership meta tag

### DIFF
--- a/src/app/(landing)/layout.tsx
+++ b/src/app/(landing)/layout.tsx
@@ -17,7 +17,7 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: "Rozo Rewards",
-  description: "Pay with USDC. Earn cashback instantly.",
+  description: "Pay with USDC. Earn cashback.",
   robots: { index: false, follow: false },
   other: {
     "base:app_id": "6a3ddd166c2d0cbe7329c3e7",

--- a/src/app/(landing)/layout.tsx
+++ b/src/app/(landing)/layout.tsx
@@ -19,6 +19,9 @@ export const metadata: Metadata = {
   title: "Rozo Rewards",
   description: "Pay with USDC. Earn cashback instantly.",
   robots: { index: false, follow: false },
+  other: {
+    "base:app_id": "6a3ddd166c2d0cbe7329c3e7",
+  },
 };
 
 export const viewport: Viewport = {

--- a/src/app/(landing)/layout.tsx
+++ b/src/app/(landing)/layout.tsx
@@ -17,7 +17,7 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: "Rozo Rewards",
-  description: "Pay with USDC. Earn cashback.",
+  description: "Pay with stablecoins. Earn cashback.",
   robots: { index: false, follow: false },
   other: {
     "base:app_id": "6a3ddd166c2d0cbe7329c3e7",

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -29,11 +29,11 @@ export default function LandingPage() {
           <h1 className="text-[2rem] font-semibold leading-[1.15] tracking-tight text-balance mb-3">
             Spend stablecoins.
             <br />
-            Earn real cashback.
+            Earn cashback.
           </h1>
           <p className="text-sm text-muted-foreground leading-relaxed max-w-[280px]">
             Pay at partner merchants with USDC and get up to{" "}
-            <span className="font-mono font-medium text-foreground">15%</span>{" "}
+            <span className="font-mono font-medium text-foreground">10%</span>{" "}
             back in ROZO points.
           </p>
         </div>


### PR DESCRIPTION
## Changes

Landing page (`/`) updates:

1. **Headline copy**: `Earn real cashback.` → `Earn cashback.` (two-line layout unchanged)
2. **Cashback rate copy**: `up to 15%` → `up to 10%`
3. **Base app verification**: add the `base:app_id` ownership meta tag to the homepage `<head>` via `metadata.other`, so Base can verify ownership.

```html
<meta name="base:app_id" content="6a3ddd166c2d0cbe7329c3e7" />
```

Files: `src/app/(landing)/page.tsx`, `src/app/(landing)/layout.tsx`. 5 lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)