### PR TITLE
feat(landing): home icon header + ROZO OG announcement dialog

### DIFF
--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -1,4 +1,5 @@
 import { LandingAppStoreSection } from "@/components/landing/landing-app-store-section";
+import { RozoOgNotice } from "@/components/landing/rozo-og-notice";
 import { getAllRestaurants } from "@/lib/restaurants";
 import { ArrowRight } from "lucide-react";
 import Image from "next/image";
@@ -89,6 +90,9 @@ export default function LandingPage() {
         >
           Discover more <ArrowRight className="size-4" />
         </Link>
+
+        {/* ROZO OG announcement */}
+        <RozoOgNotice />
       </section>
 
       <LandingAppStoreSection />

--- a/src/app/(main)/ns/[handle]/page.tsx
+++ b/src/app/(main)/ns/[handle]/page.tsx
@@ -33,7 +33,7 @@ export default function RestaurantDetailPage() {
   if (!restaurant) {
     return (
       <div className="w-full mb-16 flex flex-col gap-4 mt-4 px-4">
-        <PageHeader title="Back to Discovery" isBackButton />
+        <PageHeader title="" isHomeButton />
         <Card className="w-full">
           <CardContent className="flex flex-col items-center justify-center p-8 text-center">
             <p className="text-destructive text-lg font-medium mb-2">

--- a/src/components/landing/rozo-og-notice.tsx
+++ b/src/components/landing/rozo-og-notice.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { ArrowRight } from "lucide-react";
+
+export function RozoOgNotice() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center justify-center gap-2 w-full py-3 rounded-xl border border-border text-sm font-medium hover:bg-muted transition-colors"
+        >
+          ROZO OG <ArrowRight className="size-4" />
+        </button>
+      </DialogTrigger>
+
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>ROZO OG</DialogTitle>
+          <DialogDescription className="leading-relaxed">
+            🎉 Cashback rewards are coming in July 2026.
+            <br />
+            Thanks for being an early supporter.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Button asChild className="w-full">
+          <a
+            href="https://og.rozo.ai/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View balance at Legacy page
+            <ArrowRight className="size-4" />
+          </a>
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { ArrowLeft, History } from "lucide-react";
+import { ArrowLeft, History, Home } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { PaymentHistoryList } from "./payment-history-list";
@@ -19,12 +19,15 @@ export function PageHeader({
   title,
   icon,
   isBackButton,
+  isHomeButton,
   paymentHistoryAddress,
   onBack,
 }: {
   title: string;
   icon?: React.ReactNode;
   isBackButton?: boolean;
+  /** Render a Home icon button on the left that navigates to "/". */
+  isHomeButton?: boolean;
   /**
    * Optional wallet address used to scope the payment history sheet.
    * - When provided, history will only show receipts for this address.
@@ -41,22 +44,36 @@ export function PageHeader({
     <div
       className={cn(
         "flex items-center justify-between px-4 sm:px-0",
-        isBackButton && "pl-0",
+        (isBackButton || isHomeButton) && "pl-0",
       )}
     >
       <div className="flex items-center gap-2">
-        {isBackButton && (
+        {isHomeButton ? (
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => (onBack ? onBack() : router.back())}
+            onClick={() => router.push("/")}
             className="shrink-0 size-8"
+            aria-label="Home"
           >
-            <ArrowLeft className="size-4" />
+            <Home className="size-4" />
           </Button>
+        ) : (
+          isBackButton && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => (onBack ? onBack() : router.back())}
+              className="shrink-0 size-8"
+            >
+              <ArrowLeft className="size-4" />
+            </Button>
+          )
         )}
         {icon}
-        <h1 className="text-lg sm:text-2xl font-bold">{title}</h1>
+        {title && (
+          <h1 className="text-lg sm:text-2xl font-bold">{title}</h1>
+        )}
       </div>
 
       <Sheet open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>

--- a/src/components/restaurant/restaurant-detail-base.tsx
+++ b/src/components/restaurant/restaurant-detail-base.tsx
@@ -65,7 +65,7 @@ export function RestaurantDetailBase({
           onBack={onBack}
         />
       ) : (
-        <PageHeader title="Back to Discovery" isBackButton />
+        <PageHeader title="" isHomeButton />
       )}
 
       {/* Payment Card */}


### PR DESCRIPTION
## Summary
- Replace the "Back to Discovery" header on NS/discovery merchant pages with an icon-only **Home** button that navigates to `/`.
- `PageHeader`: add `isHomeButton` mode and skip rendering the `h1` when `title` is empty (icon-only header).
- Add a **ROZO OG** announcement on the landing page, directly below "Discover more" and styled to match that button.
- Clicking ROZO OG opens a dialog: cashback-coming notice + a "View balance at Legacy page" link to https://og.rozo.ai/.

## Files
- `src/components/page-header.tsx` — `isHomeButton` + conditional title
- `src/components/restaurant/restaurant-detail-base.tsx` — icon-only home header
- `src/app/(main)/ns/[handle]/page.tsx` — icon-only home header (not-found fallback)
- `src/app/(landing)/page.tsx` — render `<RozoOgNotice />`
- `src/components/landing/rozo-og-notice.tsx` — new client component (card + dialog)

## Test
- Verified locally on `/` and `/ns/nscafe` (HTTP 200): home button navigates to `/`, ROZO OG card aligns with Discover more, dialog opens with correct copy and link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)