### PR TITLE
ci(review): upgrade to Sonnet 5 + dual auth + 3h sweep

### DIFF
--- a/.github/ai_pr_review.py
+++ b/.github/ai_pr_review.py
@@ -35,18 +35,38 @@ import urllib.request
 from pathlib import Path
 
 # ── Model + pricing ──────────────────────────────────────────────────────────
-# PR review is a bounded, high-volume task -> Sonnet 4.6 is the cost/quality pick
-# (claude-api skill: balanced speed/intelligence for production workloads).
-MODEL = "claude-sonnet-4-6"
+# PR review is a bounded task -> Sonnet 5 (near-Opus quality on code review at
+# Sonnet cost). claude-api skill: exact id "claude-sonnet-5" (no date suffix).
+MODEL = "claude-sonnet-5"
 ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
-# $/1M tokens (claude-api skill cached table, 2026-05-26).
+# $/1M tokens (claude-api skill cached table). Sonnet 5 standard rate = $3 / $15
+# (intro $2 / $10 through 2026-08-31 — we bill the standard rate to stay safe).
 PRICE_IN_PER_MTOK = 3.00
 PRICE_OUT_PER_MTOK = 15.00
 
 AGENT_NAME = "github-pr-review"
 PASS_LABEL = "ai-review-passed"
 DEFAULT_TRUSTED_AUTHORS = ""
+
+# On-demand slash command. A comment fires a (paid) review only when this token
+# appears at the start of the comment or on its own line — not mid-word (so
+# "preview" never matches) and not when quoted inside prose. Case-insensitive.
+REVIEW_COMMAND = "/ai-review"
+_COMMAND_RE = re.compile(
+    r"(?im)^[ \t>*_-]*" + re.escape(REVIEW_COMMAND) + r"(?:\b|$)"
+)
+
+
+def comment_requests_review(body: str) -> bool:
+    """True iff a PR comment body explicitly invokes the /ai-review command.
+
+    The GHA `contains()` pre-filter is a loose substring match; this is the
+    strict second gate: the command must head a line (optionally behind quote /
+    list markers like `>` `-` `*`), so `preview this` or a sentence merely
+    mentioning `/ai-review` inside a paragraph does not trigger a paid run.
+    """
+    return bool(_COMMAND_RE.search(body or ""))
 
 # ── Budget guardrails (overridable via env in the workflow) ──────────────────
 DEFAULT_DAILY_USD_CAP = 10.00     # cumulative spend ceiling for this agent
@@ -109,10 +129,52 @@ class BudgetExceeded(Exception):
     """Raised when a hard budget cap is hit before/after the model call."""
 
 
-def call_claude(api_key: str, diff: str, *, max_tokens: int, max_retries: int) -> dict:
+def resolve_credentials() -> tuple[str, str] | None:
+    """Pick a credential from the environment. Returns (kind, secret) or None.
+
+    Preference order:
+      1. ANTHROPIC_API_KEY  → ("api_key", ...)      — plain API key, own billing.
+      2. CLAUDE_CODE_OAUTH_TOKEN → ("oauth_token", ...) — Claude Code / subscription
+         OAuth token (the same secret the Anthropic claude-code-action uses).
+    API key wins when both are present: it has independent billing and rate limits,
+    so it won't draw down the subscription. Either one is enough — you do NOT need
+    to create a new API key if the OAuth token is already an org secret.
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if api_key:
+        return ("api_key", api_key)
+    oauth = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+    if oauth:
+        return ("oauth_token", oauth)
+    return None
+
+
+def _auth_headers(creds: tuple[str, str]) -> dict[str, str]:
+    """Build the auth + version headers for either credential kind.
+
+    creds = (kind, secret). Two kinds, per the claude-api skill:
+      * "api_key"     → `x-api-key: <sk-ant-...>` (a plain API key).
+      * "oauth_token" → `Authorization: Bearer <token>` PLUS the beta header
+        `anthropic-beta: oauth-2025-04-20` (a Claude Code / subscription OAuth
+        token, e.g. CLAUDE_CODE_OAUTH_TOKEN). OAuth tokens are NOT accepted on
+        `x-api-key` — converting is a header change, not a key swap.
+    The secret is only ever placed in a header and is NEVER logged.
+    """
+    kind, secret = creds
+    base = {"content-type": "application/json", "anthropic-version": ANTHROPIC_VERSION}
+    if kind == "oauth_token":
+        base["authorization"] = f"Bearer {secret}"   # header only — never printed
+        base["anthropic-beta"] = "oauth-2025-04-20"
+    else:  # api_key
+        base["x-api-key"] = secret                    # header only — never printed
+    return base
+
+
+def call_claude(creds: tuple[str, str], diff: str, *, max_tokens: int, max_retries: int) -> dict:
     """Return {"text": str, "usage": dict}. Retries on 429/5xx with backoff.
 
-    The api_key is only ever placed in the request header. It is NEVER logged.
+    creds = (kind, secret) — see _auth_headers(). The secret is only ever placed
+    in the request header. It is NEVER logged.
     """
     if len(diff) > DIFF_CHAR_BUDGET:
         diff = diff[:DIFF_CHAR_BUDGET] + "\n\n[... diff truncated for length ...]"
@@ -120,20 +182,21 @@ def call_claude(api_key: str, diff: str, *, max_tokens: int, max_retries: int) -
     body = json.dumps({
         "model": MODEL,
         "max_tokens": max_tokens,
+        # Sonnet 5 defaults to adaptive thinking; a PR review is a simple bounded
+        # task that doesn't need it. Disable it explicitly to save tokens and
+        # avoid the response getting truncated by thinking eating max_tokens.
+        "thinking": {"type": "disabled"},
         "system": SYSTEM_PROMPT,
         "messages": [{"role": "user", "content": f"Review this diff:\n\n{diff}"}],
     }).encode("utf-8")
 
+    headers = _auth_headers(creds)
     last_err: Exception | None = None
     for attempt in range(1, max_retries + 1):
         req = urllib.request.Request(
             ANTHROPIC_URL,
             data=body,
-            headers={
-                "content-type": "application/json",
-                "x-api-key": api_key,               # header only — never printed
-                "anthropic-version": ANTHROPIC_VERSION,
-            },
+            headers=headers,
             method="POST",
         )
         try:
@@ -304,9 +367,9 @@ def _project_root_for_brain() -> Path | None:
 
 def raise_budget_alert(cost: float, cap: float, *, send: bool) -> None:
     """Feishu alert (dry-run by default) that the daily cap was breached."""
-    title = f"agent {AGENT_NAME} 成本超限"
-    text = (f"{AGENT_NAME} 累计成本估算 ${cost:.2f} 超过日上限 ${cap:.2f}，"
-            f"PR review 已停跑，请检查是否失控。")
+    title = f"agent {AGENT_NAME} over budget"
+    text = (f"{AGENT_NAME} cumulative cost estimate ${cost:.2f} exceeds the daily "
+            f"cap ${cap:.2f}. PR review has stopped — check for a runaway.")
     root = _project_root_for_brain()
     if root is not None:
         notify = root / "scripts" / "notify_feishu.py"
@@ -411,6 +474,21 @@ def main() -> int:
     max_tokens = int(os.environ.get("AI_REVIEW_MAX_TOKENS", DEFAULT_MAX_TOKENS))
     max_retries = int(os.environ.get("AI_REVIEW_MAX_RETRIES", DEFAULT_MAX_RETRIES))
 
+    # ── on-demand gate: comment triggers require the real /ai-review command ──
+    # The GHA `contains()` guard already dropped comments without the substring;
+    # this is the strict second parse (start-of-line, not mid-word). A comment
+    # event that slipped through without the real command exits cleanly — no
+    # diff read, no budget check, no model call.
+    event_name = os.environ.get("EVENT_NAME", "")
+    if event_name == "issue_comment":
+        if not comment_requests_review(os.environ.get("COMMENT_BODY", "")):
+            msg = (f"Comment does not invoke `{REVIEW_COMMAND}` on its own line — "
+                   f"skipping (no review).")
+            print(msg)
+            write_step_summary(msg)
+            set_output("verdict", "skipped-no-command")
+            return 0
+
     diff = Path(args.diff_file).read_text(encoding="utf-8", errors="replace")
     if not diff.strip():
         print("Empty diff — nothing to review.")
@@ -440,12 +518,13 @@ def main() -> int:
                          "- Example P2 nit for dry-run.")
         usage = {"input_tokens": 1200, "output_tokens": 300}
     else:
-        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
-        if not api_key:
-            eprint("ANTHROPIC_API_KEY not set — cannot run review.")
+        creds = resolve_credentials()
+        if creds is None:
+            eprint("Neither ANTHROPIC_API_KEY nor CLAUDE_CODE_OAUTH_TOKEN set — "
+                   "cannot run review.")
             return 1
         try:
-            result = call_claude(api_key, diff, max_tokens=max_tokens, max_retries=max_retries)
+            result = call_claude(creds, diff, max_tokens=max_tokens, max_retries=max_retries)
         except Exception as e:  # network / API failure -> record + fail soft
             err = f"{type(e).__name__}: {e}"
             eprint(f"Review call failed: {err}")

--- a/.github/ai_pr_sweep.py
+++ b/.github/ai_pr_sweep.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""ai_pr_sweep — scheduled cloud sweep of open PRs (every-3h safety net).
+
+Runs inside GitHub Actions on `schedule` / `workflow_dispatch`. For THIS repo it:
+
+    list open PRs  ->  keep trusted-author, non-bot, non-draft
+                   ->  skip any whose HEAD SHA == last-reviewed SHA (unchanged)
+                   ->  for the rest: compute base..head diff, call ai_pr_review.py,
+                      then stamp a hidden marker comment with the reviewed SHA
+
+"Last-reviewed SHA" is tracked **statelessly** by a hidden marker comment the
+sweep leaves on the PR:  <!-- ai-review-sha: <sha> -->
+No server-side state, reliable across throwaway runners. Head unchanged since the
+marker → skip (no duplicate comment, no wasted spend). This mirrors the local
+routine's SHA-skip, but the record lives on the PR instead of a local file.
+
+Why a separate script from ai_pr_review.py: the reviewer handles ONE known PR
+(diff handed to it); the sweep discovers WHICH PRs need review. It shells out to
+ai_pr_review.py per PR so the actual review logic + budget guardrails are not
+duplicated.
+
+Security: runs only on the base repo's own schedule (never a fork context), so
+the Anthropic credential (ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN — either
+works, see ai_pr_review.resolve_credentials) is present. This script does not
+call Anthropic directly; it inherits the full environment via dict(os.environ)
+and hands the credential down to ai_pr_review.py, which builds the right auth
+header. Uses stdlib only (urllib) + git + the Actions GITHUB_TOKEN. No secret is
+ever printed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO = os.environ["GITHUB_REPOSITORY"]
+DEFAULT_BRANCH = os.environ.get("DEFAULT_BRANCH", "main")
+TOKEN = os.environ.get("GITHUB_TOKEN", "")
+TRUSTED = {a.strip().lower()
+           for a in os.environ.get("AI_REVIEW_TRUSTED_AUTHORS", "").split(",") if a.strip()}
+REVIEW_SCRIPT = Path(__file__).resolve().parent / "ai_pr_review.py"
+MARKER_RE = re.compile(r"<!--\s*ai-review-sha:\s*([0-9a-f]{7,40})\s*-->", re.IGNORECASE)
+DIFF_CHAR_BUDGET = 200_000
+
+
+def eprint(*a: object) -> None:
+    print(*a, file=sys.stderr)
+
+
+def gh_api(path: str, method: str = "GET", body: dict | None = None) -> object:
+    """GitHub REST via stdlib. Token only in header, never printed."""
+    url = f"https://api.github.com/{path.lstrip('/')}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url, data=data, method=method,
+        headers={
+            "authorization": f"Bearer {TOKEN}",
+            "accept": "application/vnd.github+json",
+            "content-type": "application/json",
+            "user-agent": "ai-pr-sweep",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        raw = resp.read().decode()
+    return json.loads(raw) if raw else {}
+
+
+def list_open_prs() -> list[dict]:
+    """All open PRs (paginated). Each has number/user/head/draft."""
+    out: list[dict] = []
+    page = 1
+    while True:
+        batch = gh_api(f"repos/{REPO}/pulls?state=open&per_page=100&page={page}")
+        if not isinstance(batch, list) or not batch:
+            break
+        out.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return out
+
+
+def last_reviewed_sha(pr_number: int) -> str | None:
+    """Read the newest ai-review-sha marker from the PR's comments, if any."""
+    found: str | None = None
+    page = 1
+    while True:
+        batch = gh_api(f"repos/{REPO}/issues/{pr_number}/comments?per_page=100&page={page}")
+        if not isinstance(batch, list) or not batch:
+            break
+        for c in batch:
+            m = MARKER_RE.search(c.get("body", "") or "")
+            if m:
+                found = m.group(1)  # later pages are newer → keep last match
+        if len(batch) < 100:
+            break
+        page += 1
+    return found
+
+
+def stamp_marker(pr_number: int, sha: str) -> None:
+    """Leave a hidden marker comment recording the reviewed head SHA."""
+    body = (f"<!-- ai-review-sha: {sha} -->\n"
+            f"<sub>ai-pr-review swept this head (`{sha[:7]}`).</sub>")
+    try:
+        gh_api(f"repos/{REPO}/issues/{pr_number}/comments", "POST", {"body": body})
+    except urllib.error.HTTPError as e:
+        eprint(f"  marker stamp failed (non-fatal): HTTP {e.code}")
+
+
+def compute_diff(pr: dict, dest: Path) -> bool:
+    """Fetch base + head and write base...head diff to dest. Returns True on success.
+
+    Ref/repo values are validated + passed as `--`-separated args (no shell/arg
+    injection: attacker-controlled branch/fork names can't reach a shell or a git
+    option slot)."""
+    base_ref = pr["base"]["ref"]
+    head_ref = pr["head"]["ref"]
+    head_repo = (pr["head"]["repo"] or {}).get("full_name", "")
+    if not re.match(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$", head_repo):
+        eprint(f"  refusing suspicious head_repo: {head_repo!r}")
+        return False
+    for ref in (base_ref, head_ref):
+        if not re.match(r"^[A-Za-z0-9._/-]+$", ref):
+            eprint(f"  refusing suspicious ref: {ref!r}")
+            return False
+    # git workdir: the full ai-pr-review.yml checks the review script out into a
+    # `trusted/` subdir; the standalone ai-pr-sweep.yml checks out to the repo
+    # root (no `path:`). Adapt to whichever is present so one script fits both.
+    cwd = Path("trusted") if Path("trusted").is_dir() else Path(".")
+    try:
+        subprocess.run(["git", "remote", "add", "pr", f"https://github.com/{head_repo}.git"],
+                       cwd=cwd, capture_output=True)
+        subprocess.run(["git", "remote", "set-url", "pr", f"https://github.com/{head_repo}.git"],
+                       cwd=cwd, capture_output=True)
+        subprocess.run(["git", "fetch", "--no-tags", "origin", "--", base_ref],
+                       cwd=cwd, capture_output=True, timeout=120)
+        subprocess.run(["git", "fetch", "--no-tags", "pr", "--", head_ref],
+                       cwd=cwd, capture_output=True, timeout=120)
+        diff = subprocess.run(["git", "diff", f"origin/{base_ref}...FETCH_HEAD"],
+                              cwd=cwd, capture_output=True, text=True, timeout=120)
+        if diff.returncode != 0:
+            eprint(f"  git diff failed: {diff.stderr.strip()[:120]}")
+            return False
+        dest.write_text(diff.stdout)
+        return True
+    except (subprocess.SubprocessError, OSError) as e:
+        eprint(f"  diff error: {type(e).__name__}")
+        return False
+
+
+def review_pr(pr: dict) -> None:
+    num = pr["number"]
+    head_sha = pr["head"]["sha"]
+    diff_path = Path(f"/tmp/pr-{num}.diff")
+    if not compute_diff(pr, diff_path):
+        eprint(f"  #{num}: diff unavailable — skipping")
+        return
+    env = dict(os.environ)
+    env["PR_NUMBER"] = str(num)
+    env["PR_AUTHOR"] = (pr.get("user") or {}).get("login", "")
+    env["EVENT_NAME"] = "schedule"          # not a comment → no /ai-review gate
+    env.pop("COMMENT_BODY", None)
+    r = subprocess.run(
+        [sys.executable, str(REVIEW_SCRIPT), "--diff-file", str(diff_path)],
+        env=env, capture_output=True, text=True, timeout=300,
+    )
+    for line in (r.stdout + r.stderr).strip().splitlines()[-3:]:
+        print(f"    | {line}")
+    if r.returncode == 0:
+        stamp_marker(num, head_sha)         # record what we just reviewed
+    else:
+        eprint(f"  #{num}: review exited {r.returncode} — marker not stamped (will retry next sweep)")
+    try:
+        diff_path.unlink()
+    except OSError:
+        pass
+
+
+def main() -> int:
+    if not TRUSTED:
+        print("AI_REVIEW_TRUSTED_AUTHORS is empty — nothing to sweep (set the org var).")
+        return 0
+    prs = list_open_prs()
+    print(f"Sweep {REPO}: {len(prs)} open PR(s); trusted authors = {sorted(TRUSTED)}")
+    reviewed = skipped = 0
+    for pr in prs:
+        num = pr["number"]
+        author = (pr.get("user") or {}).get("login", "").lower()
+        is_bot = (pr.get("user") or {}).get("type", "") == "Bot" \
+            or author.endswith("[bot]") or author.startswith("app/")
+        head_sha = pr["head"]["sha"]
+        if pr.get("draft"):
+            print(f"  skip #{num}: draft"); skipped += 1; continue
+        if is_bot:
+            print(f"  skip #{num}: bot ({author})"); skipped += 1; continue
+        if author not in TRUSTED:
+            print(f"  skip #{num}: author {author} not trusted"); skipped += 1; continue
+        prev = last_reviewed_sha(num)
+        if prev and head_sha.startswith(prev):
+            print(f"  skip #{num}: head {head_sha[:7]} unchanged since last review"); skipped += 1; continue
+        print(f"  review #{num}: head {head_sha[:7]} "
+              f"({'new' if not prev else 'moved from ' + prev[:7]}) — '{pr.get('title','')[:50]}'")
+        review_pr(pr)
+        reviewed += 1
+    print(f"Sweep done: reviewed {reviewed}, skipped {skipped}.")
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a") as f:
+            f.write(f"Scheduled sweep: reviewed {reviewed}, skipped {skipped} "
+                    f"(of {len(prs)} open PRs).\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -109,6 +109,7 @@ jobs:
           # never echo it. On fork PRs this secret is simply absent (see boundary
           # note above) and the script exits cleanly without reviewing.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Actions-provided token — no PAT needed for same-repo comment/label.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Separate fine-grained PAT for actual approvals. Leave unset to get
@@ -123,7 +124,7 @@ jobs:
           AI_REVIEW_MAX_TOKENS: "4000"
           AI_REVIEW_MAX_RETRIES: "3"
         run: |
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
+          if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
             echo "No ANTHROPIC_API_KEY in this context (likely a fork PR) — skipping AI review."
             echo "AI review skipped: no API key in this context (fork PR safety boundary)." >> "$GITHUB_STEP_SUMMARY"
             exit 0

--- a/.github/workflows/ai-pr-sweep.yml
+++ b/.github/workflows/ai-pr-sweep.yml
@@ -1,0 +1,69 @@
+# AI PR Sweep — 3h scheduled safety net for repos that ALREADY have ai-pr-review.
+#
+# ┌───────────────────────────────────────────────────────────────────────────┐
+# │ Use this ONLY where an AI PR reviewer (.github/ai_pr_review.py) is already  │
+# │ installed and you just want to ADD a scheduled sweep. Do NOT install this   │
+# │ alongside the full ai-pr-review.yml — that file already contains a `sweep`  │
+# │ job. This standalone file is for the "sweep-only add-on" case (e.g.         │
+# │ rozo-intents-api, which had the reviewer but no cron).                      │
+# └───────────────────────────────────────────────────────────────────────────┘
+#
+# It reuses the repo's EXISTING .github/ai_pr_review.py (ai_pr_sweep.py calls
+# `Path(__file__).parent / "ai_pr_review.py"`), shares the same
+# AI_REVIEW_DAILY_USD_CAP, and does not touch the installed reviewer at all.
+# Reviews only trusted-author (AI_REVIEW_TRUSTED_AUTHORS) non-bot non-draft PRs
+# whose head SHA moved since the last review (tracked by a hidden marker comment).
+
+name: AI PR Sweep
+
+on:
+  schedule:
+    - cron: "0 */3 * * *"   # every 3 hours (UTC)
+  workflow_dispatch: {}     # manual "Run workflow" button for testing
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ai-pr-sweep-${{ github.repository }}
+  cancel-in-progress: false   # let a running sweep finish; don't cancel mid-review
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (has .github/ai_pr_review.py + ai_pr_sweep.py)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sweep open PRs and review the ones whose head moved
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Uses the SAME credential the installed reviewer uses (ANTHROPIC_API_KEY).
+          # Not the OAuth dual-auth path — keep this repo's reviewer copy unchanged.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          AI_REVIEW_APPROVER_TOKEN: ${{ secrets.AI_REVIEW_APPROVER_TOKEN }}
+          AI_REVIEW_TRUSTED_AUTHORS: ${{ vars.AI_REVIEW_TRUSTED_AUTHORS }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          BASE_REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          # MUST match the installed ai-pr-review.yml so the daily cap is shared.
+          AI_REVIEW_DAILY_USD_CAP: "10.00"
+          AI_REVIEW_MAX_TOKENS: "4000"
+          AI_REVIEW_MAX_RETRIES: "3"
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "No ANTHROPIC_API_KEY — cannot sweep. It should already be set for the installed reviewer." >&2
+            echo "Sweep skipped: ANTHROPIC_API_KEY not configured." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          python3 "${GITHUB_WORKSPACE}/.github/ai_pr_sweep.py"


### PR DESCRIPTION
Upgrades this repo's AI reviewer to match rozo-intents-api: Sonnet 5 (no thinking), dual auth (works on the org's CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY), and a 3h scheduled sweep. Adds ai_pr_sweep.py + ai-pr-sweep.yml; replaces ai_pr_review.py; patches ai-pr-review.yml to pass the OAuth token.