### PR TITLE
feat(ns): show offline-merchant notice before redirecting to discovery

### DIFF
--- a/src/app/(main)/ns/[handle]/page.tsx
+++ b/src/app/(main)/ns/[handle]/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { Card, CardContent } from "@/components/ui/card";
 import { getRestaurantByHandle } from "@/lib/restaurants";
+import { Loader2 } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import React, { useEffect, useState } from "react";
@@ -32,12 +34,27 @@ export default function RestaurantDetailPage() {
 
   useEffect(() => {
     if (!restaurant) {
-      router.replace("/discovery");
+      const timer = setTimeout(() => router.replace("/discovery"), 2500);
+      return () => clearTimeout(timer);
     }
   }, [restaurant, router]);
 
   if (!restaurant) {
-    return null;
+    return (
+      <div className="w-full mb-16 flex flex-col gap-4 mt-4 px-4">
+        <Card className="w-full">
+          <CardContent className="flex flex-col items-center justify-center p-8 text-center">
+            <Loader2 className="size-5 animate-spin text-muted-foreground mb-3" />
+            <p className="text-foreground font-medium mb-1">
+              This merchant might be offline
+            </p>
+            <p className="text-muted-foreground text-sm">
+              Taking you to Discovery…
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
   }
 
   if (isRozoWallet) {


### PR DESCRIPTION
## Summary
Unknown `/ns/[handle]` routes (e.g. `/ns/zen`) now show a brief notice — spinner + "This merchant might be offline / Taking you to Discovery…" — for 2.5 seconds before redirecting to `/discovery`, instead of redirecting silently.

## Testing
- `tsc --noEmit` clean (excluding pre-existing stale `.next/types` artifacts)
- Verified on local dev server: `/ns/zen` renders the notice card, then lands on `/discovery` after ~2.5s; known handles (`/ns/dol`) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)