### PR TITLE
feat(ns): hide NS Dolcevita and Paper Cottage for now

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -80,6 +80,7 @@ export const LOCATIONS = [
     is_live: true,
     ns_id: "dol",
     price: "$$",
+    hidden: true,
   },
   {
     _id: "58c62be12697d882a8b03e60",
@@ -100,6 +101,7 @@ export const LOCATIONS = [
     is_live: true,
     ns_id: "paper",
     price: "$",
+    hidden: true,
   },
 ];
 

--- a/src/lib/restaurants.ts
+++ b/src/lib/restaurants.ts
@@ -1,7 +1,11 @@
 import type { Restaurant } from "@/types/restaurant";
 import { LOCATIONS } from "./data";
 
-const locations = LOCATIONS as unknown as Restaurant[];
+// Hidden merchants are excluded everywhere: lists and direct /ns/[handle]
+// lookups (direct visits then fall into the offline-notice redirect).
+const locations = (LOCATIONS as unknown as Restaurant[]).filter(
+  (l) => !l.hidden,
+);
 
 const locationsById = new Map(locations.map((l) => [l._id, l]));
 const locationsByHandle = new Map(locations.map((l) => [l.handle, l]));

--- a/src/types/restaurant.ts
+++ b/src/types/restaurant.ts
@@ -18,4 +18,5 @@ export type Restaurant = {
   ns_id?: string;
   is_live?: boolean;
   currency?: string;
+  hidden?: boolean;
 };


### PR DESCRIPTION
## Summary
- Add an optional `hidden` flag to `Restaurant` and filter hidden merchants in `src/lib/restaurants.ts` (single choke point for lists and handle lookups).
- Mark `dol` (NS Dolcevita) and `paper` (Paper Cottage) as hidden: they disappear from Discovery/dapp lists, and direct `/ns/dol` / `/ns/paper` visits show the offline-merchant notice then redirect to `/discovery`.
- Backend `pos_dol` / `pos_paper` merchants stay onboarded; re-enabling is a one-line flag flip.

## Testing
- `tsc --noEmit` clean (excluding stale `.next/types` artifacts)
- Local dev: Discovery lists only NS Cafe / Ride / Rozo Studio; `/ns/dol` renders "This merchant might be offline" and redirects (same code path as unknown handles, verified in prod on /ns/zen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)