### PR TITLE
fix(ci): only pull_request events cancel in-flight AI review runs

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -34,10 +34,13 @@ permissions:
   pull-requests: write
   issues: write
 
-# One in-flight review per PR; a new push/comment cancels the previous run.
+# One in-flight review per PR. Only pull_request events (new pushes) cancel an
+# in-flight run; comment-triggered runs queue instead. Otherwise ANY PR comment
+# (e.g. the Vercel bot's preview comment) enters this group, cancels the real
+# review, and then skips itself on the job-level guard — killing the review.
 concurrency:
   group: ai-pr-review-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   review:


### PR DESCRIPTION
## Summary
Synced from the canonical ainative template.

The per-PR concurrency group used `cancel-in-progress: true` for every trigger, so ANY PR comment (e.g. the Vercel bot's preview comment) cancelled the real in-flight `pull_request` review run and then skipped itself on the job-level guard — the review silently never ran. Observed on #46, #47 and #49 (each needed a manual rerun).

Now only `pull_request` events (new pushes) cancel an in-flight run; comment-triggered runs queue instead:
`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)