### PR TITLE
feat(seo): OG share image, sitemap, robots; open indexing

### DIFF
--- a/src/app/(landing)/layout.tsx
+++ b/src/app/(landing)/layout.tsx
@@ -1,4 +1,6 @@
 import { LandingProviders } from "@/providers/landing-providers";
+import { generateOgMetadata } from "@/lib/og-image";
+import { SITE_URL_OBJECT } from "@/lib/site";
 import type { Metadata, Viewport } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import "../globals.css";
@@ -15,10 +17,30 @@ const jetbrainsMono = JetBrains_Mono({
   display: "swap",
 });
 
+const LANDING_TITLE = "Rozo Rewards";
+const LANDING_DESCRIPTION = "Pay with stablecoins. Earn cashback.";
+
+// The root URL (rewards.rozo.ai) is served by THIS (landing) route group — the
+// full OG/Twitter setup previously lived only in (main), which the root never
+// hits, so shared links had no preview image. Wire the dynamic /api/og card in
+// here, set metadataBase so relative OG/canonical URLs resolve to the right
+// origin, and open the site up to indexing (this is now a public rewards/
+// discovery site, not a private mini-app).
 export const metadata: Metadata = {
-  title: "Rozo Rewards",
-  description: "Pay with stablecoins. Earn cashback.",
-  robots: { index: false, follow: false },
+  // generateOgMetadata supplies title/description/openGraph/twitter; the fields
+  // below add what it doesn't cover (base URL, canonical, base miniapp id).
+  ...generateOgMetadata({
+    title: LANDING_TITLE,
+    description: LANDING_DESCRIPTION,
+    ogImageParams: {
+      type: "homepage",
+      title: LANDING_TITLE,
+      subtitle: LANDING_DESCRIPTION,
+      image: process.env.NEXT_PUBLIC_APP_HERO_IMAGE || "/logo.png",
+    },
+  }),
+  metadataBase: SITE_URL_OBJECT,
+  alternates: { canonical: "/" },
   other: {
     "base:app_id": "6a3ddd166c2d0cbe7329c3e7",
   },

--- a/src/app/(main)/ai-services/[domain]/layout.tsx
+++ b/src/app/(main)/ai-services/[domain]/layout.tsx
@@ -33,6 +33,12 @@ export async function generateMetadata({
       description: service.description,
       images: service.logoUrl ? [service.logoUrl] : undefined,
     },
+    twitter: {
+      card: "summary_large_image",
+      title: service.name,
+      description: service.description,
+      images: service.logoUrl ? [service.logoUrl] : undefined,
+    },
     other: {
       "service:id": service.id,
       "service:name": service.name,

--- a/src/app/(main)/ai-services/layout.tsx
+++ b/src/app/(main)/ai-services/layout.tsx
@@ -4,7 +4,6 @@ import { Metadata } from "next";
 export const metadata: Metadata = {
   title: "AI Services | Rozo",
   description: "Discover AI services and tools for enhanced experiences",
-  robots: { index: false, follow: false },
 };
 
 export default function AiServicesLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/(main)/discovery/layout.tsx
+++ b/src/app/(main)/discovery/layout.tsx
@@ -4,7 +4,6 @@ import { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Discovery | Rozo",
   description: "Discover merchants and AI services for enhanced experiences",
-  robots: { index: false, follow: false },
 };
 
 export default function DiscoveryLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,6 +1,7 @@
 import IntercomInitializer from "@/components/intercom";
 import { BookmarkProvider } from "@/contexts/BookmarkContext";
 import { generateOgMetadata } from "@/lib/og-image";
+import { SITE_URL_OBJECT } from "@/lib/site";
 import Web3ProviderClient from "@/providers/Web3ProviderClient";
 import { wagmiConfig } from "@/providers/Web3Provider";
 import type { Metadata, Viewport } from "next";
@@ -41,7 +42,7 @@ export async function generateMetadata(): Promise<Metadata> {
   });
 
   return {
-    robots: { index: false, follow: false },
+    metadataBase: SITE_URL_OBJECT,
     ...ogMetadata,
   };
 }

--- a/src/app/(main)/ns/[handle]/layout.tsx
+++ b/src/app/(main)/ns/[handle]/layout.tsx
@@ -27,13 +27,21 @@ export async function generateMetadata({
     ? `${addressParts}${priceInfo}${cashbackInfo}`
     : "View restaurant details, address and pay with crypto.";
 
+  const ogImages = restaurant?.logo_url ? [restaurant.logo_url] : undefined;
+
   return {
     title,
     description,
     openGraph: {
       title: restaurant?.name,
       description,
-      images: restaurant?.logo_url ? [restaurant.logo_url] : undefined,
+      images: ogImages,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: restaurant?.name,
+      description,
+      images: ogImages,
     },
     alternates: { canonical: `/ns/${handle}` },
     other: restaurant

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+// Public rewards / discovery site. Allow crawling of the landing and discovery
+// surfaces; keep private/transactional and logged-in merchant paths out of the
+// index. Individual private routes ( /merchants ) also set noindex in their own
+// layout as defence-in-depth.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/", "/merchants", "/pay", "/qr", "/refer"],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+import { getAllRestaurants } from "@/lib/restaurants";
+import { getAllAiServices } from "@/lib/ai-services";
+
+// Static + data-driven sitemap for the public discovery surfaces. Restaurants
+// are already filtered to exclude hidden merchants (see lib/restaurants), so
+// only live, shareable pages are listed. Private/transactional routes are
+// omitted here and disallowed in robots.ts.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: `${SITE_URL}/`, changeFrequency: "weekly", priority: 1.0 },
+    { url: `${SITE_URL}/discovery`, changeFrequency: "daily", priority: 0.9 },
+    { url: `${SITE_URL}/ai-services`, changeFrequency: "daily", priority: 0.8 },
+  ];
+
+  const restaurantRoutes: MetadataRoute.Sitemap = getAllRestaurants().map(
+    (r) => ({
+      url: `${SITE_URL}/ns/${(r as { handle: string }).handle}`,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    }),
+  );
+
+  const aiServiceRoutes: MetadataRoute.Sitemap = getAllAiServices().map((s) => ({
+    url: `${SITE_URL}/ai-services/${(s as { id: string }).id}`,
+    changeFrequency: "weekly",
+    priority: 0.6,
+  }));
+
+  return [...staticRoutes, ...restaurantRoutes, ...aiServiceRoutes];
+}

--- a/src/lib/og-image.ts
+++ b/src/lib/og-image.ts
@@ -25,7 +25,12 @@ function getOgImageUrl({
   originalPrice,
   cashbackRate,
 }: OgImageParams): string {
-  const baseUrl = process.env.NEXT_PUBLIC_URL || "https://rewards.rozo.ai";
+  // Trim any trailing slash so NEXT_PUBLIC_URL="https://rewards.rozo.ai/"
+  // doesn't produce a double-slash ".../\/api/og" URL that some scrapers reject.
+  const baseUrl = (process.env.NEXT_PUBLIC_URL || "https://rewards.rozo.ai").replace(
+    /\/+$/,
+    "",
+  );
   const endpoint = `${baseUrl}/api/og`;
 
   const params = new URLSearchParams({

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,14 @@
+// Canonical site URL used for metadataBase and absolute OG image URLs.
+//
+// NEXT_PUBLIC_URL is set to "https://rewards.rozo.ai/" (with a trailing slash)
+// in the environment, which produced double-slash OG URLs like ".../\/api/og".
+// Trim it here once so every consumer gets a clean base.
+//
+// rewards.rozo.ai is the primary host; ns.rozo.ai / dev.rozo.ai are aliases.
+// metadataBase resolves relative canonical/OG URLs against this single origin —
+// acceptable since the OG image content is identical across hosts.
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_URL || "https://rewards.rozo.ai"
+).replace(/\/+$/, "");
+
+export const SITE_URL_OBJECT = new URL(SITE_URL);


### PR DESCRIPTION
## What

The production root URL (`rewards.rozo.ai`) is served by the `(landing)` route group, whose layout had **no OpenGraph/Twitter metadata** — shared links rendered with no preview image. The full `/api/og` dynamic-card setup only lived in `(main)`, which the root never hits.

## Changes

**OG / social preview**
- Wire `generateOgMetadata` (dynamic `/api/og` card) into `(landing)/layout.tsx` so the root URL finally has a preview image.
- Set `metadataBase` (was missing everywhere) so relative OG/canonical URLs resolve to the right origin.
- Trim the trailing slash on `NEXT_PUBLIC_URL` so OG image URLs no longer contain a double slash (`.../\/api/og`) that some scrapers reject.
- Add `twitter: summary_large_image` to the `/ns/[handle]` and `/ai-services/[domain]` share pages (were OG-only, no Twitter large image).

**SEO / indexing**
- Open the public rewards/discovery surfaces to indexing (root, `/discovery`, `/ai-services`, `/ns/*`, `/ai-services/*`) — previously all `noindex` from the mini-app era. Logged-in `/merchants` stays `noindex`.
- Add `robots.ts` (allow public, disallow `api`/private/transactional) and `sitemap.ts` (static routes + live merchants + AI services, hidden merchants already excluded upstream).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `next build` clean — `robots.txt`/`sitemap.xml` prerender static, no dynamic-usage regressions
- [x] Local prod server: root page now emits full og/twitter meta (no double-slash), `robots.txt` + `sitemap.xml` correct, `/api/og` homepage card renders 1200×630

_Note: opening indexing was an explicit product decision (this is now a public rewards/discovery site, not a private mini-app)._