### PR TITLE
fix(og): NS merchant share copy drops location

### DIFF
--- a/src/app/(main)/ns/[handle]/layout.tsx
+++ b/src/app/(main)/ns/[handle]/layout.tsx
@@ -16,19 +16,8 @@ export async function generateMetadata({
     ? `${restaurant.name} @ Network School | ROZO`
     : "Restaurant Details | ROZO";
 
-  const addressParts = [restaurant?.address_line1, restaurant?.address_line2]
-    .filter(Boolean)
-    .join(", ");
-
-  const priceInfo = restaurant?.price ? ` • ${restaurant.price}` : "";
-  const cashbackInfo =
-    restaurant?.cashback_rate && restaurant.cashback_rate > 0
-      ? ` • ${restaurant.cashback_rate}% Cashback`
-      : "";
-
-  const description = restaurant
-    ? `${addressParts}${priceInfo}${cashbackInfo}`
-    : "View restaurant details, address and pay with crypto.";
+  // Share preview copy: no location, same line as the NS landing card.
+  const description = "Pay with stablecoins at NS. Earn cashback.";
 
   // OG image is provided by the sibling opengraph-image.tsx (branded centered
   // card). Don't set openGraph/twitter images here or it overrides the file
@@ -50,14 +39,12 @@ export async function generateMetadata({
       description,
     },
     alternates: { canonical: `/ns/${handle}` },
+    // No location tags (address / geo) — share preview must not reveal location.
     other: restaurant
       ? {
           "restaurant:name": restaurant.name,
-          "restaurant:address": addressParts,
           "restaurant:price": restaurant.price || "",
           "restaurant:cashback_rate": restaurant.cashback_rate.toString(),
-          "geo:latitude": restaurant.lat.toString(),
-          "geo:longitude": restaurant.lon.toString(),
         }
       : undefined,
   };


### PR DESCRIPTION
## What

Merchant `/ns/<handle>` share previews were showing the street address (e.g. "Forest City Marina Hotel, Jalan Forest City • $ • 1% Cashback"). Per feedback, the preview should not reveal location and should read the same as the NS landing card.

## Changes

- `description` + og/twitter description → `Pay with stablecoins at NS. Earn cashback.` (no address).
- Remove `restaurant:address` and `geo:latitude`/`geo:longitude` meta tags so no location leaks into the preview.
- Title unchanged: `<Merchant> @ Network School | ROZO`. OG image (centered card) unchanged.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `next build` clean
- [x] Local prod server: nscafe description is the fixed NS line, no address/geo tags present