### PR TITLE
feat(ns): unhide Paper Cottage + route to backend merchant_paper

### DIFF
--- a/src/components/restaurant/restaurant-dapp-detail.tsx
+++ b/src/components/restaurant/restaurant-dapp-detail.tsx
@@ -28,7 +28,7 @@ export function RestaurantDappDetail({
   });
 
   const [appId] = React.useState<string>(
-    () => `pos_${restaurant?.handle || ""}`,
+    () => restaurant?.app_id ?? `pos_${restaurant?.handle || ""}`,
   );
 
   const [merchantOrderId] = React.useState<string>(

--- a/src/components/restaurant/restaurant-discovery-payment.tsx
+++ b/src/components/restaurant/restaurant-discovery-payment.tsx
@@ -79,7 +79,7 @@ export function RestaurantDiscoveryPayment({
     try {
       const displayCurrency = getDisplayCurrency(restaurant.currency);
       const response = await createMerchantPayment({
-        appId: `pos_${restaurant.handle}`,
+        appId: restaurant.app_id ?? `pos_${restaurant.handle}`,
         amount_local: paymentAmount,
         currency_local: displayCurrency,
         source: { chainId: "8453", tokenSymbol: "USDC" },

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -92,16 +92,15 @@ export const LOCATIONS = [
     address_line2: " Jalan Forest City",
     lat: 1.3361,
     lon: 103.5938,
-    payTo: "0x2352Fa2970dBadD12d21808DB0F56CDEC8141739",
+    payTo: "0x157D4d35d8963dAF9Fc636A090AD69d0BD9fd60c",
     createdAt: "2026-01-08T12:19:15.152Z",
-    updatedAt: "2026-07-11T00:00:00.000Z",
+    updatedAt: "2026-07-16T00:00:00.000Z",
     __v: 0,
     logo_url: "https://dcdn.rozo.ai/papercottage.png",
     cashback_rate: 1,
     is_live: true,
     ns_id: "paper",
     price: "$",
-    hidden: true,
   },
 ];
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -92,7 +92,8 @@ export const LOCATIONS = [
     address_line2: " Jalan Forest City",
     lat: 1.3361,
     lon: 103.5938,
-    payTo: "0x157D4d35d8963dAF9Fc636A090AD69d0BD9fd60c",
+    // Receiving address lives in the backend merchant (app_id below), not here.
+    app_id: "merchant_paper",
     createdAt: "2026-01-08T12:19:15.152Z",
     updatedAt: "2026-07-16T00:00:00.000Z",
     __v: 0,

--- a/src/types/restaurant.ts
+++ b/src/types/restaurant.ts
@@ -19,4 +19,8 @@ export type Restaurant = {
   is_live?: boolean;
   currency?: string;
   hidden?: boolean;
+  // Backend merchant app_id override. Defaults to `pos_${handle}` when absent.
+  // Set explicitly for merchants whose backend id doesn't follow that convention
+  // (e.g. non-custodial intent-forwarding merchants like `merchant_paper`).
+  app_id?: string;
 };


### PR DESCRIPTION
## What

Re-enable the **Paper Cottage** (`/ns/paper`) merchant page and route its payments to the merchant's own non-custodial wallet **via the backend**, not a hardcoded frontend address.

## Key insight

NS merchant payments do **not** use `data.ts` `payTo` — that field is dead code. The receiving address is resolved at runtime by the backend merchant, keyed by `appId` (default `pos_<handle>`). So the source of truth for the address is the backend `merchants` row, not the frontend.

Paper Cottage's backend merchant is **`merchant_paper`** — a non-custodial *intent-forwarding* merchant that settles USDC on Base directly to the merchant's own wallet (`0x157D…d60c`). It doesn't follow the `pos_<handle>` naming, so the frontend needs to target that app_id explicitly.

## Changes

- `types/restaurant.ts`: add optional `app_id` to override the default `pos_${handle}`.
- Both payment paths (`restaurant-discovery-payment.tsx`, `restaurant-dapp-detail.tsx`): use `restaurant.app_id ?? pos_${handle}`.
- `data.ts` Paper Cottage record:
  - `app_id: "merchant_paper"` (backend owns the address)
  - **drop the dead `payTo`** — no receiving address hardcoded in the frontend
  - remove `hidden: true` so `/ns/paper` resolves again (hidden in #49) and its auto-generated OG share card ("Paper Cottage @ Network School") renders.

## Backend (done separately, not in this PR)

`merchant_paper` created in rozo-intents-api `merchants` (intent-forwarding, `to_chain=8453 / to_token=USDC / to_address=0x157D…d60c`, `is_pos=false`, `custody_type=self`). Order creation verified: `createMerchantPayment(appId:"merchant_paper")` returns a checkout link whose `destination.receiverAddress = 0x157D…d60c`.

## Scope

- Only Paper Cottage is touched; other merchants keep `pos_<handle>`.
- Lint clean. `0x157D…d60c` verified not on the compromised-wallet blacklist.