### PR TITLE
feat(analytics): enable PostHog exception autocapture

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -15,6 +15,9 @@ if (POSTHOG_KEY) {
   posthog.init(POSTHOG_KEY, {
     api_host:
       process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
+    // Auto-capture unhandled JS errors and promise rejections as $exception
+    // events (does not capture console.error). Mirrors rozo-invoice#31.
+    capture_exceptions: true,
   });
   posthog.register({ app_name: "rozo-rewards-miniapp" });
 }


### PR DESCRIPTION
## What

Adds `capture_exceptions: true` to the PostHog `posthog.init(...)` config in
`src/instrumentation-client.ts` so unhandled JS errors and promise rejections are
also captured as `$exception` events in PostHog (in addition to the existing
Sentry error tracking). Does **not** enable `console.error` capture.

## Why

Gives PostHog-side crash visibility consistent with the other Rozo front-ends so
the hourly PostHog `$exception` sweep covers rewards.rozo.ai too. Additive —
Sentry is untouched.

## Precedent

Mirrors `RozoAI/rozo-invoice#31` (merged, live on invoice.rozo.ai). Installed
posthog-js (1.39x) supports `capture_exceptions?: boolean`.

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Post-merge: production bundle grep confirms `capture_exceptions`; page renders 200
