### PR TITLE
feat(merchant): website + WhatsApp links, hosted-by avatars, drop disclaimer

### DIFF
--- a/src/components/restaurant/restaurant-detail-base.tsx
+++ b/src/components/restaurant/restaurant-detail-base.tsx
@@ -12,7 +12,6 @@ import {
   getFirstTwoWordInitialsFromName,
 } from "@/lib/utils";
 import { Restaurant } from "@/types/restaurant";
-import { Info } from "lucide-react";
 import React, { useEffect, useRef } from "react";
 
 export interface RestaurantDetailBaseProps {
@@ -90,6 +89,32 @@ export function RestaurantDetailBase({
               >
                 {restaurant.name}
               </h2>
+              {restaurant.website && (
+                <a
+                  href={`https://${restaurant.website}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block truncate text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                >
+                  {restaurant.website}
+                </a>
+              )}
+              {restaurant.host && (
+                <div className="mt-1 flex items-center gap-1.5">
+                  <Avatar className="size-4 rounded-full ring-1 ring-border bg-muted shrink-0">
+                    <AvatarImage
+                      src={restaurant.host.avatar_url}
+                      alt={restaurant.host.name}
+                    />
+                    <AvatarFallback className="text-[8px] font-medium">
+                      {restaurant.host.name[0]?.toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="text-xs text-muted-foreground truncate">
+                    Hosted by {restaurant.host.name}
+                  </span>
+                </div>
+              )}
             </div>
           </div>
 
@@ -138,15 +163,8 @@ export function RestaurantDetailBase({
                 )}
               </div>
 
-              {isDapp && (
-                <div className="flex items-start gap-1.5">
-                  <Info className="size-4 text-muted-foreground" />
-                  <p className="text-left text-xs text-muted-foreground">
-                    Physical goods & services only. No digital content or in-app
-                    features.
-                  </p>
-                </div>
-              )}
+              {/* "Physical goods & services only" disclaimer removed for all
+                  merchants (owner 2026-07-17). */}
 
               {/* Payment Buttons */}
               {paymentSlot}

--- a/src/components/restaurant/restaurant-detail-base.tsx
+++ b/src/components/restaurant/restaurant-detail-base.tsx
@@ -89,18 +89,35 @@ export function RestaurantDetailBase({
               >
                 {restaurant.name}
               </h2>
-              {restaurant.website && (
-                <a
-                  href={`https://${restaurant.website}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block truncate text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
-                >
-                  {restaurant.website}
-                </a>
+              {(restaurant.website || restaurant.whatsapp) && (
+                <div className="flex items-center gap-2">
+                  {restaurant.website && (
+                    <a
+                      href={`https://${restaurant.website}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="truncate text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                    >
+                      {restaurant.website}
+                    </a>
+                  )}
+                  {restaurant.whatsapp && (
+                    <a
+                      href={restaurant.whatsapp}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="shrink-0 text-xs text-green-700 dark:text-green-400 underline underline-offset-2 hover:opacity-80"
+                    >
+                      WhatsApp
+                    </a>
+                  )}
+                </div>
               )}
               {restaurant.host && (
                 <div className="mt-1 flex items-center gap-1.5">
+                  <span className="text-xs text-muted-foreground shrink-0">
+                    Hosted by
+                  </span>
                   <Avatar className="size-4 rounded-full ring-1 ring-border bg-muted shrink-0">
                     <AvatarImage
                       src={restaurant.host.avatar_url}
@@ -111,7 +128,7 @@ export function RestaurantDetailBase({
                     </AvatarFallback>
                   </Avatar>
                   <span className="text-xs text-muted-foreground truncate">
-                    Hosted by {restaurant.host.name}
+                    {restaurant.host.name}
                   </span>
                 </div>
               )}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -53,6 +53,8 @@ export const LOCATIONS = [
     lon: 103.5938,
     // Receiving address lives in the backend merchant (app_id below), not here.
     app_id: "merchant_paper",
+    website: "papercottage.site",
+    host: { name: "Tara" },
     createdAt: "2026-01-08T12:19:15.152Z",
     updatedAt: "2026-07-16T00:00:00.000Z",
     __v: 0,
@@ -75,6 +77,8 @@ export const LOCATIONS = [
     lon: 103.5938,
     // Receiving address lives in the backend merchant (app_id below), not here.
     app_id: "merchant_parallelsociety",
+    website: "parallelsociety.shop",
+    host: { name: "Romina" },
     createdAt: "2026-07-17T00:00:00.000Z",
     updatedAt: "2026-07-17T00:00:00.000Z",
     __v: 0,
@@ -118,6 +122,7 @@ export const LOCATIONS = [
     lat: 1.3411,
     lon: 103.5874,
     payTo: "0x2352Fa2970dBadD12d21808DB0F56CDEC8141739",
+    host: { name: "shawnmuggle" },
     createdAt: "2025-08-09T12:21:20.572Z",
     updatedAt: "2025-08-09T12:21:20.572Z",
     __v: 0,

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -11,6 +11,10 @@ export const LOCATIONS = [
     lat: 1.3361,
     lon: 103.5938,
     payTo: "0x2352Fa2970dBadD12d21808DB0F56CDEC8141739",
+    host: {
+      name: "Network School",
+      avatar_url: "https://dcdn.rozo.ai/ns-logo.webp",
+    },
     createdAt: "2025-08-09T12:21:20.572Z",
     updatedAt: "2025-08-09T12:21:20.572Z",
     __v: 0,
@@ -32,6 +36,10 @@ export const LOCATIONS = [
     lat: 1.3359,
     lon: 103.5938,
     payTo: "0x2352Fa2970dBadD12d21808DB0F56CDEC8141739",
+    website: "sgmytaxi288service.com",
+    // Ride is the only merchant with a WhatsApp contact link (owner 2026-07-17).
+    whatsapp: "https://wa.me/60192551688",
+    host: { name: "Carol" },
     createdAt: "2025-08-09T12:21:20.572Z",
     updatedAt: "2025-08-09T12:21:20.572Z",
     __v: 0,
@@ -54,7 +62,11 @@ export const LOCATIONS = [
     // Receiving address lives in the backend merchant (app_id below), not here.
     app_id: "merchant_paper",
     website: "papercottage.site",
-    host: { name: "Tara" },
+    host: {
+      name: "Tara",
+      avatar_url:
+        "https://aozudqtlykbhzbuzalzz.supabase.co/storage/v1/object/public/merchant-assets/avatars/tara.png",
+    },
     createdAt: "2026-01-08T12:19:15.152Z",
     updatedAt: "2026-07-16T00:00:00.000Z",
     __v: 0,
@@ -78,7 +90,11 @@ export const LOCATIONS = [
     // Receiving address lives in the backend merchant (app_id below), not here.
     app_id: "merchant_parallelsociety",
     website: "parallelsociety.shop",
-    host: { name: "Romina" },
+    host: {
+      name: "Romina",
+      avatar_url:
+        "https://aozudqtlykbhzbuzalzz.supabase.co/storage/v1/object/public/merchant-assets/avatars/romina.png",
+    },
     createdAt: "2026-07-17T00:00:00.000Z",
     updatedAt: "2026-07-17T00:00:00.000Z",
     __v: 0,
@@ -122,7 +138,11 @@ export const LOCATIONS = [
     lat: 1.3411,
     lon: 103.5874,
     payTo: "0x2352Fa2970dBadD12d21808DB0F56CDEC8141739",
-    host: { name: "shawnmuggle" },
+    host: {
+      name: "shawnmuggle",
+      avatar_url:
+        "https://aozudqtlykbhzbuzalzz.supabase.co/storage/v1/object/public/merchant-assets/avatars/shawnmuggle.png",
+    },
     createdAt: "2025-08-09T12:21:20.572Z",
     updatedAt: "2025-08-09T12:21:20.572Z",
     __v: 0,

--- a/src/types/restaurant.ts
+++ b/src/types/restaurant.ts
@@ -26,6 +26,8 @@ export type Restaurant = {
   // Merchant website (bare domain, no scheme) — rendered as a clickable
   // reference link on the merchant page.
   website?: string;
-  // Who runs this merchant — rendered as "Hosted by <name>" with an avatar.
+  // WhatsApp contact link (full wa.me URL) — currently only Ride uses this.
+  whatsapp?: string;
+  // Who runs this merchant — rendered as "Hosted by <avatar> <name>".
   host?: { name: string; avatar_url?: string };
 };

--- a/src/types/restaurant.ts
+++ b/src/types/restaurant.ts
@@ -23,4 +23,9 @@ export type Restaurant = {
   // Set explicitly for merchants whose backend id doesn't follow that convention
   // (e.g. non-custodial intent-forwarding merchants like `merchant_paper`).
   app_id?: string;
+  // Merchant website (bare domain, no scheme) — rendered as a clickable
+  // reference link on the merchant page.
+  website?: string;
+  // Who runs this merchant — rendered as "Hosted by <name>" with an avatar.
+  host?: { name: string; avatar_url?: string };
 };


### PR DESCRIPTION
Owner requests (2026-07-17), reviewed on localhost first.

## Changes
1. **Website reference link** on the merchant page — clickable, opens in a new tab. Paper Cottage → papercottage.site, Parallel Society → parallelsociety.shop, Ride → sgmytaxi288service.com.
2. **"Hosted by <avatar> <name>"** on the merchant page. Hosts: NS Cafe = Network School (NS logo), Ride = Carol, Paper = Tara, Parallel Society = Romina, Rozo Studio = shawnmuggle. Real photos for Romina/Tara/shawnmuggle (compressed to 96px, 1yr cache on the Supabase merchant-assets bucket); initials fallback where no photo yet.
3. **WhatsApp contact link** — Ride only (wa.me/60192551688).
4. **Removed** the "Physical goods & services only. No digital content or in-app features." disclaimer for all merchants.

## Notes
- Merchant addresses/app_ids unchanged — this is display-only. Parallel Society backend merchant (non-custodial, official-Twilio WhatsApp + owner CC) was verified live with a $0.01 order (tx 0xc59d…9f60).
- Image perf fix (root cause: Supabase Storage defaults to `cache-control: no-cache`, so browsers re-request every time): all new avatars/logos re-uploaded with `max-age=31536000` + downscaled (100-186KB → 17-22KB).
- `tsc --noEmit` clean, lint clean.