### PR TITLE
fix(merchants): redirect regular browsers to /discovery (missing Pay button)

### DIFF
--- a/src/app/(dapp-merchants)/layout.tsx
+++ b/src/app/(dapp-merchants)/layout.tsx
@@ -1,3 +1,4 @@
+import { DappBrowserGuard } from "@/components/dapp/dapp-browser-guard";
 import { BookmarkProvider } from "@/contexts/BookmarkContext";
 import type { Metadata, Viewport } from "next";
 import { ThemeProvider } from "next-themes";
@@ -50,7 +51,9 @@ export default function DappRootLayout({
             disableTransitionOnChange
           >
             <main className="flex min-h-screen flex-col justify-between md:min-h-screen md:items-center md:justify-start relative">
-              {children}
+              {/* Regular browsers (no window.rozo) are redirected to /discovery,
+                  which has working Pay buttons. Rozo App WebView passes through. */}
+              <DappBrowserGuard>{children}</DappBrowserGuard>
               <Toaster position="top-center" />
             </main>
           </ThemeProvider>

--- a/src/components/dapp/dapp-browser-guard.tsx
+++ b/src/components/dapp/dapp-browser-guard.tsx
@@ -18,25 +18,35 @@ import { useEffect } from "react";
  * useRozoWallet already handles the async injection race (waits up to 3s for the
  * `rozo:ready` event before concluding "no wallet"), so we only decide once
  * isChecking is false. While checking, show a spinner instead of a blank page.
+ *
+ * Redirect strictly on PROVIDER PRESENCE (`window.rozo` missing), NOT on
+ * isAvailable — isAvailable also goes false when the provider IS present but a
+ * bridge call (isConnected / getAddress / getBalance) transiently fails, which
+ * would wrongly eject a real Rozo App user on a network blip (codex P2).
  */
 export function DappBrowserGuard({ children }: { children: React.ReactNode }) {
-  const { isAvailable, isChecking } = useRozoWallet();
+  const { isChecking } = useRozoWallet();
   const router = useRouter();
   const pathname = usePathname();
 
+  // Only meaningful after isChecking resolves (the hook has waited for the
+  // async rozo:ready injection). A regular browser has no window.rozo.
+  const hasProvider =
+    typeof window !== "undefined" && !!window.rozo;
+
   useEffect(() => {
     if (isChecking) return;
-    if (!isAvailable) {
+    if (!hasProvider) {
       // Regular browser — send to the discovery experience (has Pay buttons).
       // Preserve any query string (e.g. filters) on the redirect.
       const qs =
         typeof window !== "undefined" ? window.location.search : "";
       router.replace(`/discovery${qs}`);
     }
-  }, [isChecking, isAvailable, pathname, router]);
+  }, [isChecking, hasProvider, pathname, router]);
 
   // Still checking, or redirecting away — don't flash dapp UI to a browser user.
-  if (isChecking || !isAvailable) {
+  if (isChecking || !hasProvider) {
     return (
       <div className="flex min-h-screen w-full items-center justify-center">
         <Loader2 className="size-5 animate-spin text-muted-foreground" />

--- a/src/components/dapp/dapp-browser-guard.tsx
+++ b/src/components/dapp/dapp-browser-guard.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useRozoWallet } from "@/hooks/useRozoWallet";
+import { Loader2 } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+/**
+ * Guards the (dapp-merchants) route group, which is designed for the Rozo
+ * wallet's in-app WebView (isDapp=true → tap a merchant opens the dapp payment
+ * detail, which needs window.rozo). A regular browser has no window.rozo, so
+ * those pages render no Pay button and dead-end the user.
+ *
+ * When the wallet check resolves and NO wallet is present (regular browser),
+ * redirect to /discovery — the same merchant list in discovery mode, whose
+ * detail pages (/ns/[handle]) DO show a Pay button.
+ *
+ * useRozoWallet already handles the async injection race (waits up to 3s for the
+ * `rozo:ready` event before concluding "no wallet"), so we only decide once
+ * isChecking is false. While checking, show a spinner instead of a blank page.
+ */
+export function DappBrowserGuard({ children }: { children: React.ReactNode }) {
+  const { isAvailable, isChecking } = useRozoWallet();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (isChecking) return;
+    if (!isAvailable) {
+      // Regular browser — send to the discovery experience (has Pay buttons).
+      // Preserve any query string (e.g. filters) on the redirect.
+      const qs =
+        typeof window !== "undefined" ? window.location.search : "";
+      router.replace(`/discovery${qs}`);
+    }
+  }, [isChecking, isAvailable, pathname, router]);
+
+  // Still checking, or redirecting away — don't flash dapp UI to a browser user.
+  if (isChecking || !isAvailable) {
+    return (
+      <div className="flex min-h-screen w-full items-center justify-center">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Bug
`ns.rozo.ai/merchants` and its merchant detail pages (`/merchants/restaurant/[id]`) render **no Pay button in a regular browser**. Reported: NS Cafe detail shows the amount field but no Pay button. Confirmed all merchants, regular phone/desktop browser.

## Root cause
The `(dapp-merchants)` route group is built for the Rozo wallet's in-app WebView — `/merchants` hardcodes `isDapp=true`, so tapping a merchant opens the **dapp** payment detail, which needs `window.rozo`. A regular browser has no `window.rozo`, so the dapp detail renders no Pay button and the user dead-ends. The working payment page for regular browsers is the discovery flow (`/ns/[handle]`).

## Fix
Add `DappBrowserGuard` around the `(dapp-merchants)` layout. It reuses `useRozoWallet` (the same wallet-presence check the dapp detail already relies on, including its 3s `rozo:ready` injection race) and, once resolved with **no wallet**, redirects to `/discovery` — the same merchant list in discovery mode whose `/ns/[handle]` detail pages have working Pay buttons. Shows a spinner while checking (no blank flash). **Rozo App WebView (window.rozo present) passes through unchanged.**

## Verified locally
`/merchants` → lands on `/discovery` (full merchant list). `/merchants/restaurant/<id>` → lands on `/discovery`. tsc + lint clean.