### PR TITLE
fix(ns): label Parallel Society as '(Merch)' in storefront

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -78,7 +78,7 @@ export const LOCATIONS = [
   },
   {
     _id: "78c62be12697d882a8b03e60",
-    name: "Parallel Society",
+    name: "Parallel Society (Merch)",
     handle: "parallelsociety",
     currency: "USD",
     formatted:


### PR DESCRIPTION
Owner request: show this merchant as **Parallel Society (Merch)** in the discovery list + merchant page. Backend merchants.name already carries the same suffix, so DingTalk order notifications and invoices match. One-line data.ts change.