### PR TITLE
feat: payment link flow with paymentId query param

### DIFF
--- a/src/app/(main)/ns/[handle]/page.tsx
+++ b/src/app/(main)/ns/[handle]/page.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { PAYMENT_EVENTS } from "@/lib/analytics/events";
 import { capture } from "@/lib/analytics/index";
 import { getRestaurantByHandle } from "@/lib/restaurants";
-import { PaymentStatus, type PaymentResponse } from "@rozoai/intent-common";
+import { getPayment, PaymentStatus, type PaymentResponse } from "@rozoai/intent-common";
 import { AlertCircle, Loader2 } from "lucide-react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
@@ -22,13 +22,9 @@ const RestaurantDiscoveryDetail = dynamic(
 
 function LoadingSpinner({ text }: { text: string }) {
   return (
-    <div className="w-full mb-16 flex flex-col gap-4 mt-4 px-4">
-      <Card className="w-full">
-        <CardContent className="flex flex-col items-center justify-center p-8 text-center">
-          <Loader2 className="size-5 animate-spin text-muted-foreground mb-3" />
-          <p className="text-foreground font-medium mb-1">{text}</p>
-        </CardContent>
-      </Card>
+    <div className="flex min-h-screen w-full flex-col items-center justify-center gap-2">
+      <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      <p className="text-sm text-muted-foreground">{text}</p>
     </div>
   );
 }
@@ -72,9 +68,7 @@ function RestaurantDetailContent() {
       source: "url_param",
     });
 
-    import("@rozoai/intent-common").then(({ getPayment }) =>
-      getPayment(paymentIdParam),
-    )
+    getPayment(paymentIdParam)
       .then((response) => {
         if (response.error) {
           throw new Error(response.error.message ?? "Failed to fetch payment");

--- a/src/app/(main)/ns/[handle]/page.tsx
+++ b/src/app/(main)/ns/[handle]/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { Card, CardContent } from "@/components/ui/card";
+import { PAYMENT_EVENTS } from "@/lib/analytics/events";
+import { capture } from "@/lib/analytics/index";
 import { getRestaurantByHandle } from "@/lib/restaurants";
-import { Loader2 } from "lucide-react";
-import { useParams, useRouter } from "next/navigation";
+import { PaymentStatus, type PaymentResponse } from "@rozoai/intent-common";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
-import React, { useEffect, useState } from "react";
+import React, { Suspense, useEffect, useState } from "react";
 
 const RestaurantDappDetail = dynamic(
   () => import("@/components/restaurant/restaurant-dapp-detail").then((m) => ({ default: m.RestaurantDappDetail })),
@@ -17,11 +20,38 @@ const RestaurantDiscoveryDetail = dynamic(
   { ssr: false },
 );
 
+function LoadingSpinner({ text }: { text: string }) {
+  return (
+    <div className="w-full mb-16 flex flex-col gap-4 mt-4 px-4">
+      <Card className="w-full">
+        <CardContent className="flex flex-col items-center justify-center p-8 text-center">
+          <Loader2 className="size-5 animate-spin text-muted-foreground mb-3" />
+          <p className="text-foreground font-medium mb-1">{text}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 export default function RestaurantDetailPage() {
+  return (
+    <Suspense fallback={<LoadingSpinner text="Loading..." />}>
+      <RestaurantDetailContent />
+    </Suspense>
+  );
+}
+
+function RestaurantDetailContent() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const handle = params.handle as string;
+  const paymentIdParam = searchParams.get("paymentId");
+
   const [isRozoWallet, setIsRozoWallet] = useState(false);
+  const [prefilledPayment, setPrefilledPayment] = useState<PaymentResponse | null>(null);
+  const [isLoadingPayment, setIsLoadingPayment] = useState(false);
+  const [paymentError, setPaymentError] = useState<string | null>(null);
 
   useEffect(() => {
     setIsRozoWallet(typeof window !== "undefined" && !!window.rozo);
@@ -32,12 +62,83 @@ export default function RestaurantDetailPage() {
     [handle],
   );
 
+  // Fetch payment data when paymentId is provided
+  useEffect(() => {
+    if (!paymentIdParam) return;
+
+    setIsLoadingPayment(true);
+    capture(PAYMENT_EVENTS.PAYMENT_LINK_OPENED, {
+      payment_id: paymentIdParam,
+      source: "url_param",
+    });
+
+    import("@rozoai/intent-common").then(({ getPayment }) =>
+      getPayment(paymentIdParam),
+    )
+      .then((response) => {
+        if (response.error) {
+          throw new Error(response.error.message ?? "Failed to fetch payment");
+        }
+
+        const payment = response.data;
+        if (!payment) {
+          throw new Error("No payment data returned");
+        }
+
+        if (payment.status === PaymentStatus.PaymentUnpaid) {
+          setPrefilledPayment(payment);
+          capture(PAYMENT_EVENTS.PAYMENT_LINK_LOADED, {
+            payment_id: paymentIdParam,
+            payment_status: payment.status,
+          });
+        } else {
+          setPaymentError(
+            payment.status === PaymentStatus.PaymentCompleted
+              ? "This payment has already been completed."
+              : `This payment cannot be processed (status: ${payment.status}).`
+          );
+          capture(PAYMENT_EVENTS.PAYMENT_LINK_ERROR, {
+            payment_id: paymentIdParam,
+            payment_status: payment.status,
+            error_message: `Payment status: ${payment.status}`,
+          });
+        }
+      })
+      .catch((err) => {
+        console.error("[PaymentLink] Failed to fetch payment:", err);
+        setPaymentError("Failed to load payment details. Please try again.");
+        capture(PAYMENT_EVENTS.PAYMENT_LINK_ERROR, {
+          payment_id: paymentIdParam,
+          error_message: err instanceof Error ? err.message : "Unknown error",
+        });
+      })
+      .finally(() => setIsLoadingPayment(false));
+  }, [paymentIdParam]);
+
   useEffect(() => {
     if (!restaurant) {
       const timer = setTimeout(() => router.replace("/discovery"), 2500);
       return () => clearTimeout(timer);
     }
   }, [restaurant, router]);
+
+  if (isLoadingPayment) {
+    return <LoadingSpinner text="Loading payment details..." />;
+  }
+
+  if (paymentError) {
+    return (
+      <div className="w-full mb-16 flex flex-col gap-4 mt-4 px-4">
+        <Card className="w-full">
+          <CardContent className="flex flex-col items-center justify-center p-8 text-center">
+            <AlertCircle className="size-8 text-destructive mb-3" />
+            <p className="text-foreground font-medium mb-1">Payment Issue</p>
+            <p className="text-muted-foreground text-sm">{paymentError}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   if (!restaurant) {
     return (
@@ -70,6 +171,7 @@ export default function RestaurantDetailPage() {
     <RestaurantDiscoveryDetail
       restaurant={restaurant}
       onBack={() => router.push("/discovery")}
+      prefilledPayment={prefilledPayment}
     />
   );
 }

--- a/src/components/restaurant/restaurant-discovery-detail.tsx
+++ b/src/components/restaurant/restaurant-discovery-detail.tsx
@@ -32,9 +32,9 @@ export function RestaurantDiscoveryDetail({
 
   const [loading, setLoading] = React.useState(false);
   const [paymentAmount, setPaymentAmount] = React.useState<string>(() => {
-    // Use prefilled amount from payment link if available
+    // Use prefilled amount from payment link if available (strip trailing zeros)
     if (prefilledPayment?.source?.amount) {
-      return prefilledPayment.source.amount;
+      return String(parseFloat(prefilledPayment.source.amount));
     }
     const price =
       restaurant?.price && !isNaN(Number(restaurant.price))

--- a/src/components/restaurant/restaurant-discovery-detail.tsx
+++ b/src/components/restaurant/restaurant-discovery-detail.tsx
@@ -33,6 +33,9 @@ export function RestaurantDiscoveryDetail({
   const [loading, setLoading] = React.useState(false);
   const [paymentAmount, setPaymentAmount] = React.useState<string>(() => {
     // Use prefilled amount from payment link if available (strip trailing zeros)
+    if (prefilledPayment?.metadata?.amount_local) {
+      return String(parseFloat(prefilledPayment.metadata.amount_local));
+    }
     if (prefilledPayment?.source?.amount) {
       return String(parseFloat(prefilledPayment.source.amount));
     }

--- a/src/components/restaurant/restaurant-discovery-detail.tsx
+++ b/src/components/restaurant/restaurant-discovery-detail.tsx
@@ -2,6 +2,7 @@
 
 import { RestaurantDetailBase } from "@/components/restaurant/restaurant-detail-base";
 import { convertToUSD, getDisplayCurrency } from "@/lib/utils";
+import { type PaymentResponse } from "@rozoai/intent-common";
 import { Restaurant } from "@/types/restaurant";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
@@ -19,16 +20,22 @@ const RestaurantDiscoveryPayment = dynamic(
 export interface RestaurantDiscoveryDetailProps {
   restaurant: Restaurant;
   onBack?: () => void;
+  prefilledPayment?: PaymentResponse | null;
 }
 
 export function RestaurantDiscoveryDetail({
   restaurant,
   onBack,
+  prefilledPayment,
 }: RestaurantDiscoveryDetailProps) {
   const router = useRouter();
 
   const [loading, setLoading] = React.useState(false);
   const [paymentAmount, setPaymentAmount] = React.useState<string>(() => {
+    // Use prefilled amount from payment link if available
+    if (prefilledPayment?.source?.amount) {
+      return prefilledPayment.source.amount;
+    }
     const price =
       restaurant?.price && !isNaN(Number(restaurant.price))
         ? Number(restaurant.price)
@@ -119,6 +126,7 @@ export function RestaurantDiscoveryDetail({
             generateMetadata={generateMetadata}
             loading={loading}
             setLoading={setLoading}
+            prefilledPayment={prefilledPayment}
           />
         }
       />

--- a/src/components/restaurant/restaurant-discovery-payment.tsx
+++ b/src/components/restaurant/restaurant-discovery-payment.tsx
@@ -12,7 +12,7 @@ import { PaymentCompletedEvent } from "@rozoai/intent-common";
 import { RozoPayButton } from "@rozoai/intent-pay";
 import { CreditCard, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 interface RestaurantDiscoveryPaymentProps {
@@ -24,6 +24,10 @@ interface RestaurantDiscoveryPaymentProps {
   generateMetadata: (amountLocal: string, currencyLocal: string) => object;
   loading: boolean;
   setLoading: (value: boolean) => void;
+  prefilledPayment?: {
+    id: string;
+    source: { amount: string };
+  } | null;
 }
 
 export function RestaurantDiscoveryPayment({
@@ -35,15 +39,18 @@ export function RestaurantDiscoveryPayment({
   generateMetadata,
   loading,
   setLoading,
+  prefilledPayment,
 }: RestaurantDiscoveryPaymentProps) {
   const router = useRouter();
 
-  const [paymentId, setPaymentId] = React.useState<string | null>(null);
-  const [confirmedAmount, setConfirmedAmount] = React.useState<string | null>(
-    null,
+  const [paymentId, setPaymentId] = React.useState<string | null>(
+    prefilledPayment?.id ?? null,
   );
-  const [isCreatingPayment, setIsCreatingPayment] = React.useState(false);
-  const [isPreparingPayment, setIsPreparingPayment] = React.useState(false);
+  const [confirmedAmount, setConfirmedAmount] = useState<string | null>(
+    prefilledPayment?.source?.amount ?? null,
+  );
+  const [isCreatingPayment, setIsCreatingPayment] = useState(false);
+  const [isPreparingPayment, setIsPreparingPayment] = useState(false);
   const showRef = useRef<(() => void) | null>(null);
 
   // Reset payment when amount changes
@@ -83,7 +90,10 @@ export function RestaurantDiscoveryPayment({
         amount_local: paymentAmount,
         currency_local: displayCurrency,
         source: { chainId: "8453", tokenSymbol: "USDC" },
-        metadata: { dataSuffix: DATA_SUFFIX },
+        metadata: {
+          dataSuffix: DATA_SUFFIX,
+          customDeeplink: `${window.location.origin}${window.location.pathname}?paymentId=`,
+        },
       });
       setPaymentId(response.id);
       setConfirmedAmount(response.source.amount ?? null);

--- a/src/components/restaurant/restaurant-discovery-payment.tsx
+++ b/src/components/restaurant/restaurant-discovery-payment.tsx
@@ -27,6 +27,7 @@ interface RestaurantDiscoveryPaymentProps {
   prefilledPayment?: {
     id: string;
     source: { amount?: string };
+    metadata?: { amount_local?: string } | null;
   } | null;
 }
 
@@ -43,8 +44,14 @@ export function RestaurantDiscoveryPayment({
 }: RestaurantDiscoveryPaymentProps) {
   const router = useRouter();
 
-  const prefilledAmount = prefilledPayment?.source?.amount
-    ? String(parseFloat(prefilledPayment.source.amount))
+  const prefilledAmount = prefilledPayment
+    ? String(
+        parseFloat(
+          prefilledPayment.metadata?.amount_local ??
+            prefilledPayment.source?.amount ??
+            "0",
+        ),
+      )
     : null;
   const [paymentId, setPaymentId] = React.useState<string | null>(
     prefilledPayment?.id ?? null,

--- a/src/components/restaurant/restaurant-discovery-payment.tsx
+++ b/src/components/restaurant/restaurant-discovery-payment.tsx
@@ -26,7 +26,7 @@ interface RestaurantDiscoveryPaymentProps {
   setLoading: (value: boolean) => void;
   prefilledPayment?: {
     id: string;
-    source: { amount: string };
+    source: { amount?: string };
   } | null;
 }
 

--- a/src/components/restaurant/restaurant-discovery-payment.tsx
+++ b/src/components/restaurant/restaurant-discovery-payment.tsx
@@ -43,23 +43,27 @@ export function RestaurantDiscoveryPayment({
 }: RestaurantDiscoveryPaymentProps) {
   const router = useRouter();
 
+  const prefilledAmount = prefilledPayment?.source?.amount
+    ? String(parseFloat(prefilledPayment.source.amount))
+    : null;
   const [paymentId, setPaymentId] = React.useState<string | null>(
     prefilledPayment?.id ?? null,
   );
   const [confirmedAmount, setConfirmedAmount] = useState<string | null>(
-    prefilledPayment?.source?.amount ?? null,
+    prefilledAmount,
   );
   const [isCreatingPayment, setIsCreatingPayment] = useState(false);
   const [isPreparingPayment, setIsPreparingPayment] = useState(false);
   const showRef = useRef<(() => void) | null>(null);
 
-  // Reset payment when amount changes
+  // Reset payment only when amount changes from the original prefilled value
   useEffect(() => {
+    if (prefilledAmount && paymentAmount === prefilledAmount) return;
     setPaymentId(null);
     setConfirmedAmount(null);
     setIsPreparingPayment(false);
     showRef.current = null;
-  }, [paymentAmount]);
+  }, [paymentAmount, prefilledAmount]);
 
   // Auto-open modal once paymentId is set and show function available
   useEffect(() => {
@@ -92,11 +96,15 @@ export function RestaurantDiscoveryPayment({
         source: { chainId: "8453", tokenSymbol: "USDC" },
         metadata: {
           dataSuffix: DATA_SUFFIX,
-          customDeeplink: `${window.location.origin}${window.location.pathname}?paymentId=`,
+          customDeeplinkUrl: `${window.location.origin}${window.location.pathname}?paymentId=`,
         },
       });
       setPaymentId(response.id);
-      setConfirmedAmount(response.source.amount ?? null);
+      setConfirmedAmount(
+        response.source.amount
+          ? String(parseFloat(response.source.amount))
+          : null,
+      );
     } catch (error) {
       console.error("[Restaurant] Failed to create payment:", error);
       toast.error("Failed to create payment. Please try again.");

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -18,6 +18,9 @@ export const PAYMENT_EVENTS = {
   PAYMENT_FAILED: "payment_failed",
   PAYMENT_CANCELLED: "payment_cancelled",
   PAYMENT_TX_HASH_IN_FAILED: "payment_tx_hash_in_failed",
+  PAYMENT_LINK_OPENED: "payment_link_opened",
+  PAYMENT_LINK_LOADED: "payment_link_loaded",
+  PAYMENT_LINK_ERROR: "payment_link_error",
 } as const;
 
 export const REWARDS_EVENTS = {

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -27,6 +27,9 @@ const ALLOWED_PROPERTY_KEYS = new Set([
   "fid",
   "wallet_address",
   "chain",
+  "payment_id",
+  "payment_status",
+  "source",
 ]);
 
 function sanitizeProperties(


### PR DESCRIPTION
## Summary

Adds support for payment links via a `paymentId` query parameter on the merchant detail page. When a user opens a URL like `/ns/cafe?paymentId=xxx`, the app fetches the payment, prefills the amount, and auto-opens the pay modal.

## Changes

### Merchant Detail Page (`src/app/(main)/ns/[handle]/page.tsx`)
- Reads `paymentId` from URL search params
- Fetches payment via `getPayment` from `@rozoai/intent-common` (dynamic import)
- Shows loading spinner while fetching payment details
- Shows error card for paid/failed/error payments
- Passes `prefilledPayment` to `RestaurantDiscoveryDetail`

### Discovery Payment Components
- `RestaurantDiscoveryDetail`: accepts `prefilledPayment` prop, initializes amount from it
- `RestaurantDiscoveryPayment`: initializes `paymentId` and `confirmedAmount` from prefilled data, auto-opens modal after 1s delay

### Payment Metadata (`createMerchantPayment`)
- Adds `customDeeplink` to metadata: `{origin}{pathname}?paymentId=`
- API fills in the actual paymentId

### PostHog Events (`src/lib/analytics/`)
- New events: `payment_link_opened`, `payment_link_loaded`, `payment_link_error`
- Added `payment_id`, `payment_status`, `source` to property allowlist

## Testing
1. Open `/ns/{handle}?paymentId={unpaid-id}` → should load, prefilled amount, auto-open modal
2. Open with a completed payment ID → should show "already completed" error
3. Open with invalid ID → should show error card
4. Open without paymentId → should work as before (no regression)