### PR TITLE
ci(pr-review): v2 workflow on official claude-code-action (subscription OAuth)

### DIFF
--- a/.github/workflows/ai-pr-review-v2.yml
+++ b/.github/workflows/ai-pr-review-v2.yml
@@ -1,0 +1,88 @@
+# AI PR Review (v2) — official anthropics/claude-code-action on a subscription token.
+#
+# ┌───────────────────────────────────────────────────────────────────────────┐
+# │ SECURITY BOUNDARY — DO NOT change `pull_request` to `pull_request_target`. │
+# └───────────────────────────────────────────────────────────────────────────┘
+# `pull_request` runs in the BASE repo's context but WITHOUT secrets on fork PRs,
+# so a fork PR simply gets no CLAUDE_CODE_OAUTH_TOKEN and the action no-ops. Never
+# switch to pull_request_target — that would expose the subscription token to
+# untrusted fork code.
+#
+# Why v2: the hand-rolled raw-API script (ai_pr_review.py) kept hitting HTTP 429
+# on the subscription OAuth token — its fixed 3-try backoff can't ride out the
+# subscription's tight raw-/v1/messages rate limit. claude-code-action runs the
+# Claude Code CLI internally, which has mature subscription-aware 429 backoff.
+# This file is a MINIMAL bring-up to confirm "subscription + CI, no 429 wall".
+# The structured P0/P1/P2 + ai-review-passed label + auto-approve logic from the
+# old workflow is intentionally NOT reproduced here yet — add it back once the
+# core path is proven. The old ai-pr-review.yml stays in place alongside this.
+
+name: AI PR Review v2
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# Least privilege: read the code, write PR comments. id-token for the action's
+# OIDC auth. No `issues: write` — v2 does not manage labels yet.
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+# One in-flight review per PR; a new push cancels the previous run.
+concurrency:
+  group: ai-pr-review-v2-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Trusted-author gate: only review PRs opened by a login in the repo/org
+    # variable AI_REVIEW_TRUSTED_AUTHORS (comma-separated). Keeps v2 from burning
+    # the subscription on arbitrary contributors while we validate it. Fork PRs
+    # also lack the secret, so this is belt-and-suspenders.
+    # NOTE: GHA expressions have no replace(); the substring match tolerates the
+    # surrounding commas. Keep AI_REVIEW_TRUSTED_AUTHORS space-free
+    # (`akbarsaputrait,shawnmuggle`) so `,<login>,` matches cleanly.
+    if: >
+      contains(
+        format(',{0},', vars.AI_REVIEW_TRUSTED_AUTHORS),
+        format(',{0},', github.event.pull_request.user.login)
+      )
+    steps:
+      - name: Checkout PR head (read-only; never executed with secrets)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude Code review
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Subscription OAuth token (Pro/Max). Absent on fork PRs -> action no-ops.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Non-interactive automatic run: providing `prompt` triggers a one-shot
+          # review, no @claude mention needed.
+          prompt: |
+            Review the diff of pull request #${{ github.event.pull_request.number }}
+            in ${{ github.repository }}. This is a pre-merge review for the Rozo
+            project (cross-chain USDC / stablecoin payment infrastructure).
+
+            Focus on, in priority order:
+            - P0 (blocking): leaked secret / private key / API key / JWT in code or
+              logs; weakened auth or RLS; payment / payout / withdrawal logic
+              changed with no test coverage; a blacklisted wallet used as receiver.
+            - P1 (should fix): real bugs, security weaknesses, missing error
+              handling, incorrect logic, meaningful test gaps.
+            - P2 (nice to have): style, naming, readability.
+
+            Be specific and cite file:line. Leave inline comments on specific
+            lines and one summary PR comment. If nothing blocks, say so plainly.
+            Do NOT approve or merge — a human decides.
+          # Model + tool allowlist. The allowlist is what enforces "pure code
+          # review, no network": WebSearch / WebFetch are NOT listed, so the CLI
+          # cannot reach the network. Only diff-reading + comment tools are on.
+          claude_args: |
+            --model claude-opus-4-8
+            --max-turns 15
+            --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
Minimal v2 AI PR review using anthropics/claude-code-action@v1 on the subscription OAuth token, to fix the persistent HTTP 429 the raw-API script hits.

**Why**: the hand-rolled ai_pr_review.py kept getting 429 on CLAUDE_CODE_OAUTH_TOKEN — its fixed 3-try backoff cannot ride out the subscription raw-/v1/messages rate limit. claude-code-action runs the Claude Code CLI internally, which has subscription-aware backoff.

**Scope (minimal, to prove the path)**:
- pull_request trigger only — never pull_request_target (fork PRs get no secret)
- trusted-author gate via AI_REVIEW_TRUSTED_AUTHORS
- --allowedTools allowlist excludes WebSearch/WebFetch (no network)
- --model claude-opus-4-8, auto PR comment

Does NOT yet reproduce P0/P1/P2 labels + auto-approve; old ai-pr-review.yml stays alongside. This workflow only takes effect for PRs opened AFTER it merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)