### PR TITLE
ci(pr-review): auto-approve on v2 (deterministic no-P0 gate)

### DIFF
--- a/.github/workflows/ai-pr-review-v2.yml
+++ b/.github/workflows/ai-pr-review-v2.yml
@@ -4,18 +4,22 @@
 # │ SECURITY BOUNDARY — DO NOT change `pull_request` to `pull_request_target`. │
 # └───────────────────────────────────────────────────────────────────────────┘
 # `pull_request` runs in the BASE repo's context but WITHOUT secrets on fork PRs,
-# so a fork PR simply gets no CLAUDE_CODE_OAUTH_TOKEN and the action no-ops. Never
-# switch to pull_request_target — that would expose the subscription token to
-# untrusted fork code.
+# so a fork PR gets no CLAUDE_CODE_OAUTH_TOKEN and the action no-ops. Never switch
+# to pull_request_target — that would expose the subscription token AND the
+# approver PAT to untrusted fork code.
 #
-# Why v2: the hand-rolled raw-API script (ai_pr_review.py) kept hitting HTTP 429
-# on the subscription OAuth token — its fixed 3-try backoff can't ride out the
-# subscription's tight raw-/v1/messages rate limit. claude-code-action runs the
-# Claude Code CLI internally, which has mature subscription-aware 429 backoff.
-# This file is a MINIMAL bring-up to confirm "subscription + CI, no 429 wall".
-# The structured P0/P1/P2 + ai-review-passed label + auto-approve logic from the
-# old workflow is intentionally NOT reproduced here yet — add it back once the
-# core path is proven. The old ai-pr-review.yml stays in place alongside this.
+# Why v2: the hand-rolled raw-API script kept hitting HTTP 429 on the subscription
+# OAuth token — its fixed backoff can't ride out the subscription raw-/v1/messages
+# rate limit. claude-code-action runs the Claude Code CLI internally, which has
+# subscription-aware 429 backoff.
+#
+# Auto-approve (this file): a SEPARATE, deterministic step approves the PR when
+# the review reports zero blockers — NOT the model self-approving. The action
+# returns a machine-readable verdict via --json-schema; a follow-up step reads
+# `has_blockers` and, only when false, submits an APPROVE using a dedicated
+# approver PAT (AI_REVIEW_APPROVER_TOKEN). The default Actions GITHUB_TOKEN cannot
+# approve PRs (422), and GitHub forbids approving your own PR (also 422) — both
+# are treated as a soft skip, so the review comment still lands.
 
 name: AI PR Review v2
 
@@ -23,11 +27,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
-# Least privilege: read the code, write PR comments. id-token for the action's
-# OIDC auth. No `issues: write` — v2 does not manage labels yet.
+# Least privilege. contents:read to read the diff; pull-requests:write to comment
+# + approve; issues:write to add the ai-review-passed label; id-token for the
+# action's OIDC auth.
 permissions:
   contents: read
   pull-requests: write
+  issues: write
   id-token: write
 
 # One in-flight review per PR; a new push cancels the previous run.
@@ -39,12 +45,10 @@ jobs:
   review:
     runs-on: ubuntu-latest
     # Trusted-author gate: only review PRs opened by a login in the repo/org
-    # variable AI_REVIEW_TRUSTED_AUTHORS (comma-separated). Keeps v2 from burning
-    # the subscription on arbitrary contributors while we validate it. Fork PRs
+    # variable AI_REVIEW_TRUSTED_AUTHORS (comma-separated, space-free). Fork PRs
     # also lack the secret, so this is belt-and-suspenders.
     # NOTE: GHA expressions have no replace(); the substring match tolerates the
-    # surrounding commas. Keep AI_REVIEW_TRUSTED_AUTHORS space-free
-    # (`akbarsaputrait,shawnmuggle`) so `,<login>,` matches cleanly.
+    # surrounding commas, so keep AI_REVIEW_TRUSTED_AUTHORS space-free.
     if: >
       contains(
         format(',{0},', vars.AI_REVIEW_TRUSTED_AUTHORS),
@@ -57,6 +61,7 @@ jobs:
           fetch-depth: 1
 
       - name: Claude Code review
+        id: review
         uses: anthropics/claude-code-action@v1
         with:
           # Subscription OAuth token (Pro/Max). Absent on fork PRs -> action no-ops.
@@ -68,21 +73,67 @@ jobs:
             in ${{ github.repository }}. This is a pre-merge review for the Rozo
             project (cross-chain USDC / stablecoin payment infrastructure).
 
-            Focus on, in priority order:
+            Classify every finding into exactly one severity:
             - P0 (blocking): leaked secret / private key / API key / JWT in code or
-              logs; weakened auth or RLS; payment / payout / withdrawal logic
-              changed with no test coverage; a blacklisted wallet used as receiver.
+              logs; weakened or removed auth or Supabase RLS; a public edge function
+              deploy missing --no-verify-jwt; a write to a read-only mirror table;
+              payment / payout / withdrawal logic changed with zero test coverage;
+              a blacklisted wallet address used as a receiver.
             - P1 (should fix): real bugs, security weaknesses, missing error
               handling, incorrect logic, meaningful test gaps.
             - P2 (nice to have): style, naming, readability.
 
-            Be specific and cite file:line. Leave inline comments on specific
-            lines and one summary PR comment. If nothing blocks, say so plainly.
-            Do NOT approve or merge — a human decides.
-          # Model + tool allowlist. The allowlist is what enforces "pure code
-          # review, no network": WebSearch / WebFetch are NOT listed, so the CLI
-          # cannot reach the network. Only diff-reading + comment tools are on.
+            Be specific and cite file:line. Leave inline comments on specific lines
+            and one summary PR comment. Do NOT approve or merge — a separate
+            automated step decides approval from your verdict.
+
+            After reviewing, return the structured verdict: set has_blockers to true
+            if and only if you found one or more P0 findings; put the P0 count in
+            p0_count; put a one-line summary in summary.
+          # Model + tool allowlist. The allowlist enforces "pure code review, no
+          # network": WebSearch / WebFetch are NOT listed, so the CLI cannot reach
+          # the network. `gh pr review` is deliberately NOT allowed — approval is
+          # done by the separate deterministic step below, never by the model.
+          # --json-schema makes the verdict machine-readable in
+          # steps.review.outputs.structured_output.
           claude_args: |
             --model claude-opus-4-8
             --max-turns 15
             --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment"
+            --json-schema '{"type":"object","properties":{"has_blockers":{"type":"boolean"},"p0_count":{"type":"integer"},"summary":{"type":"string"}},"required":["has_blockers","p0_count","summary"],"additionalProperties":false}'
+
+      # ── Deterministic verdict gate (NOT the model) ──────────────────────────
+      # Reads the machine-readable verdict. On zero blockers: label + approve.
+      # Approval uses the dedicated approver PAT and is best-effort: a missing
+      # token, self-approval (author == PAT owner), or org policy all 422 -> the
+      # step logs and skips without failing the job (the review comment already
+      # landed).
+      - name: Label + approve when no blockers
+        if: >
+          steps.review.outputs.structured_output != '' &&
+          fromJSON(steps.review.outputs.structured_output).has_blockers == false
+        env:
+          GH_TOKEN: ${{ secrets.AI_REVIEW_APPROVER_TOKEN }}
+          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          SUMMARY: ${{ fromJSON(steps.review.outputs.structured_output).summary }}
+        run: |
+          set -uo pipefail
+          # Label with the Actions token (can write issues). Best-effort.
+          GH_TOKEN="$FALLBACK_TOKEN" gh pr edit "$PR" --repo "$REPO" \
+            --add-label "ai-review-passed" || echo "label add skipped (may not exist / race)"
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "No AI_REVIEW_APPROVER_TOKEN configured — commenting pass, not approving."
+            echo "AI review: no blockers. (Auto-approve skipped: no approver token.)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # Approve with the dedicated PAT. 422 (self-approval / policy / dup) is a soft skip.
+          if gh pr review "$PR" --repo "$REPO" --approve \
+               --body "AI review found no P0 blockers. $SUMMARY"; then
+            echo "Approved PR #$PR." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Approve returned non-zero (likely self-approval or policy 422) — skipping." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
Adds auto-approve to the v2 claude-code-action workflow.

- Review returns structured verdict via --json-schema {has_blockers, p0_count, summary}
- A separate deterministic step (NOT the model) approves only when has_blockers==false, using the dedicated AI_REVIEW_APPROVER_TOKEN PAT
- Model never gets gh-approve (branch-protection + injection safe, per official guidance)
- Soft-skip on missing token / self-approval / policy 422; review comment + label still land

🤖 Generated with [Claude Code](https://claude.com/claude-code)