### PR TITLE
fix(analytics): truncate wallet_address and payment_id before sending to PostHog

### DIFF
--- a/src/app/(landing)/receipt/receipt-content.tsx
+++ b/src/app/(landing)/receipt/receipt-content.tsx
@@ -66,12 +66,19 @@ export default function ReceiptContent() {
   const searchParams = useSearchParams();
   const withRozoWallet = Boolean(searchParams.get("withRozoWallet"));
 
-  // ponytail: lazy init — sync read, no effect, no loading state, no 300ms delay
-  const [paymentData] = useState(() => readPaymentData(searchParams));
+  // Must start null on both server and first client render — reading
+  // sessionStorage/localStorage in a lazy initializer returns real data on
+  // the client but null on the server (no window), producing a whole-element
+  // hydration mismatch (server renders nothing, client renders the full
+  // receipt). Read happens in an effect instead, after hydration.
+  const [paymentData, setPaymentData] = useState<PaymentData | null>(null);
 
   useEffect(() => {
-    if (!paymentData) router.replace(withRozoWallet ? "/merchants" : "/");
-  }, [paymentData, withRozoWallet, router]);
+    const data = readPaymentData(searchParams);
+    setPaymentData(data);
+    if (!data) router.replace(withRozoWallet ? "/merchants" : "/");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!paymentData) {
     return null;

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -1,6 +1,10 @@
 import posthog from "posthog-js";
+import { formatAddress } from "@/lib/utils";
 import type { RozoEventName } from "./events";
 import type { IdentifyProperties } from "./properties";
+
+// Properties truncated to first6+last4 before leaving the client (B3 privacy rule).
+const TRUNCATED_PROPERTY_KEYS = new Set(["wallet_address", "payment_id"]);
 
 /**
  * Allowlist of property keys safe to send to PostHog. Anything not listed
@@ -39,9 +43,11 @@ function sanitizeProperties(
 
   const sanitized: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(properties)) {
-    if (ALLOWED_PROPERTY_KEYS.has(key) && value !== undefined) {
-      sanitized[key] = value;
-    }
+    if (!ALLOWED_PROPERTY_KEYS.has(key) || value === undefined) continue;
+    sanitized[key] =
+      TRUNCATED_PROPERTY_KEYS.has(key) && typeof value === "string"
+        ? formatAddress(value)
+        : value;
   }
   return sanitized;
 }


### PR DESCRIPTION
## Summary
- PostHog sanitizer allowlisted `wallet_address` and `payment_id` keys but sent full values as-is, violating B3 privacy rule (truncate addresses/hashes to first6+last4).
- `sanitizeProperties` now truncates these two keys via existing `formatAddress` helper at the `capture()` boundary — covers all ~15 call sites automatically, no per-site changes.
- `identifyUser()`'s `wallet_address` on the PostHog identify person-profile is left full intentionally (it mirrors `distinct_id`, the identity key itself).
- Also includes unrelated receipt page SSR fix (guards localStorage/location access during server render, moves redirect into useEffect) that was already in the working tree.

## Test plan
- [x] `bun lint` (via lefthook pre-commit) passes on changed files
- [ ] Manually verify PostHog events for wallet connect / payment flows now show truncated `wallet_address` / `payment_id`
- [ ] Confirm receipt page renders without SSR errors