### PR TITLE
fix(seo): self-referencing canonical on /discovery and /ai-services

### DIFF
--- a/src/app/(main)/ai-services/layout.tsx
+++ b/src/app/(main)/ai-services/layout.tsx
@@ -4,6 +4,10 @@ import { Metadata } from "next";
 export const metadata: Metadata = {
   title: "AI Services | Rozo",
   description: "Discover AI services and tools for enhanced experiences",
+  // Self-referencing canonical, matching the other indexable surfaces
+  // (/ns, /ns/[handle], /ai-services/[domain]). These two index pages were the
+  // only sitemap-listed URLs shipping without one.
+  alternates: { canonical: "/ai-services" },
 };
 
 export default function AiServicesLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/(main)/discovery/layout.tsx
+++ b/src/app/(main)/discovery/layout.tsx
@@ -4,6 +4,10 @@ import { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Discovery | Rozo",
   description: "Discover merchants and AI services for enhanced experiences",
+  // Self-referencing canonical, matching the other indexable surfaces
+  // (/ns, /ns/[handle], /ai-services/[domain]). These two index pages were the
+  // only sitemap-listed URLs shipping without one.
+  alternates: { canonical: "/discovery" },
 };
 
 export default function DiscoveryLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
Found while auditing indexing across all rozo.ai Search Console properties: of the sitemap-listed URLs on rewards.rozo.ai, `/discovery` and `/ai-services` were the only two rendering without a `<link rel=canonical>`. Every other indexable surface here already declares one (`/`, `/ns`, `/ns/[handle]`, `/ai-services/[domain]`), so this just closes the gap.

Verification (`bun run build` + `bun run start`):

```
/discovery   -> canonical https://rewards.rozo.ai/discovery
/ai-services -> canonical https://rewards.rozo.ai/ai-services
/ns          -> canonical https://rewards.rozo.ai/ns   (unchanged)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)