### PR TITLE
feat: add /version endpoint exposing build git sha

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,22 @@ const withBundleAnalyzer = createBundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
 
+function gitSha(): string {
+  try {
+    const sha =
+      process.env.VERCEL_GIT_COMMIT_SHA ??
+      require("child_process").execSync("git rev-parse HEAD").toString();
+    return sha.trim().slice(-4);
+  } catch {
+    return "unknown";
+  }
+}
+
 const nextConfig: NextConfig = {
+  env: {
+    // ponytail: Vercel injects the sha; local git is a best-effort fallback.
+    NEXT_PUBLIC_GIT_SHA: gitSha(),
+  },
   serverExternalPackages: ["@rozoai/intent-pay"],
   skipTrailingSlashRedirect: true,
   devIndicators: false,

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,7 +11,7 @@ function gitSha(): string {
     const sha =
       process.env.VERCEL_GIT_COMMIT_SHA ??
       require("child_process").execSync("git rev-parse HEAD").toString();
-    return sha.trim().slice(-4);
+    return sha.trim().slice(0, 7);
   } catch {
     return "unknown";
   }

--- a/src/app/version/route.ts
+++ b/src/app/version/route.ts
@@ -1,0 +1,7 @@
+export const dynamic = "force-static";
+
+export function GET() {
+  return Response.json({
+    version: process.env.NEXT_PUBLIC_GIT_SHA ?? "unknown",
+  });
+}


### PR DESCRIPTION
## Summary

Adds a `/version` endpoint returning the build's git sha, so a running deployment can be identified without guessing.

```
GET /version  ->  {"version":"1c7d5bb"}
```

## How it works

- Sha is read from `VERCEL_GIT_COMMIT_SHA` at build time (Vercel shallow-clones, so `git rev-parse` is not reliable in CI).
- Falls back to local `git rev-parse` for dev, then to `"unknown"` if neither is available.
- Inlined via the `env:` block in `next.config.ts`, so it is a static string in the bundle — no runtime cost.
- Route is `force-static`: the sha *is* the build, so per-request evaluation would be pointless.

## Testing

Booted each app and curled `/version`; output matched `git rev-parse --short=7 HEAD` in every case.